### PR TITLE
Fix YAML parsing issues with wiki-link brackets in frontmatter

### DIFF
--- a/GDPRed documentation/frontmatter-readme.md
+++ b/GDPRed documentation/frontmatter-readme.md
@@ -87,8 +87,8 @@ per-article:
 ### `ruling-articles`
 
 - **Source**: Extract from the articles explicitly mentioned in the ruling section
-- **Format**: Bulleted list with format "Article X"
-- **Process**: 
+- **Format**: Bulleted list with format `Article X` (plain text, **NO** `[[` `]]` wiki-link brackets)
+- **Process**:
   1. Identify all articles mentioned in the ruling
   2. Remove duplicates
   3. List only the article numbers
@@ -100,21 +100,44 @@ per-article:
     - Article 10
   ```
 
+> **IMPORTANT — Do NOT use `[[Article X]]` in this field.**
+> YAML interprets `[[...]]` as a nested array (flow sequence), not a string.
+> `- [[Article 13]]` parses as a nested array `[["Article 13"]]`, which breaks
+> every downstream script that calls `.match()` or `.replace()` on the value.
+> Always use plain `- Article X` format.
+
 ### `per-article`
 
 - **Source**: Created by mapping each article to the relevant portions of the ruling
-- **Format**: 
-  - "Article X | [Text that explains/interprets Article X]"
+- **Format**:
+  - `"Article X | [Text that explains/interprets Article X]"` — the entire entry must be **quoted** because it contains a YAML pipe `|` character
   - Include verbatim extracts from the final-ruling that reference each article
+  - **NO** `[[` `]]` wiki-link brackets around article references (same reason as above)
 - **Process**:
   1. For each article in ruling-articles, extract the exact text from the final-ruling that interprets it
   2. Combine multiple interpretations of the same article
   3. Format with article number followed by pipe character and relevant verbatim text
+  4. **Quote the entire value** to prevent the `|` from being interpreted as a YAML block scalar
 - **Example**:
   ```yaml
   per-article:
-    - Article 10 | **1.** Article 10(a) of Directive (EU) 2016/680... **3.** Article 10 of Directive 2016/680, read in conjunction with...
+    - "Article 10 | **1.** Article 10(a) of Directive (EU) 2016/680... **3.** Article 10 of Directive 2016/680, read in conjunction with..."
   ```
+
+> **IMPORTANT — Per-article entries must be quoted strings.**
+> The `|` (pipe) character has special meaning in YAML (block scalar indicator).
+> While it may work unquoted in some positions, quoting the value guarantees
+> correct parsing. Example of what NOT to do:
+> ```yaml
+> # WRONG — [[]] parsed as array, | may break parsing
+> per-article:
+>   - [[Article 13]] | Interpretation text here
+> ```
+> ```yaml
+> # CORRECT
+> per-article:
+>   - "Article 13 | Interpretation text here"
+> ```
 
 ## Special Formatting Notes
 
@@ -125,6 +148,8 @@ per-article:
 3. **Cross-References**: Maintain cross-references in the ruling text, especially in the `per-article` field.
 
 4. **Escaping Special Characters**: Ensure any special characters in the text are properly escaped according to YAML syntax.
+
+5. **No Wiki-Link Brackets in Frontmatter Fields**: The `ruling-articles` and `per-article` fields must use plain `Article X` format, never `[[Article X]]`. Wiki-link brackets are for markdown body content only — inside YAML frontmatter they are parsed as YAML flow sequences (arrays), causing parse errors and type crashes in downstream scripts.
 
 ## Extraction Process
 

--- a/GDPRed documentation/functions-readme.md
+++ b/GDPRed documentation/functions-readme.md
@@ -476,15 +476,28 @@ These scripts are used to generate and maintain reference files and visual eleme
 2. Article references are updated
 3. The timeline display needs refreshing
 
-To run any script:
+### Path Resolution
+
+All scripts in `scripts/` resolve content paths relative to the **project root** (one level up from the `scripts/` directory), using `path.join(__dirname, '..', 'content', ...)`. The one exception is `extract_key_articles.cjs` which lives in the project root and uses `path.join(__dirname, 'content', ...)`.
+
+### Running Scripts
+
+Scripts should be run from the **project root directory**:
 
 ```bash
-# For CommonJS scripts
-node extract_case_articles.cjs
-node process_article_refs.cjs
+# For CommonJS scripts in scripts/
+node scripts/extract_case_articles.cjs
+node scripts/process_article_refs.cjs
 
-# For ES modules
-node generate-timeline.js
-node generate-case-grid.js
-node extract_article_rulings.js
-``` 
+# For ES modules in scripts/
+node scripts/generate-timeline.js
+node scripts/generate-case-grid.js
+node scripts/extract_article_rulings.js
+
+# For CommonJS script in project root
+node extract_key_articles.cjs
+```
+
+### Frontmatter Compatibility
+
+All scripts expect `ruling-articles` and `per-article` frontmatter fields to use plain `Article X` format (no `[[]]` wiki-link brackets). See `frontmatter-readme.md` for details. 

--- a/extract_key_articles.cjs
+++ b/extract_key_articles.cjs
@@ -25,8 +25,11 @@ function extractKeyArticleRefs(metadata) {
         const rulingArticles = metadata['ruling-articles'];
 
         // The ruling-articles field is expected to be an array in the YAML
+        // Note: [[Article X]] in YAML gets parsed as a nested array, so we
+        // need to flatten and coerce to string for safety.
         if (Array.isArray(rulingArticles)) {
-            rulingArticles.forEach(article => {
+            const flatArticles = rulingArticles.flat(Infinity).map(String);
+            flatArticles.forEach(article => {
                 // Extract just the article number if it's in the format "Article X"
                 const match = article.match(/Article\s+(\d+)/);
                 if (match) {

--- a/scripts/extract_article_rulings.js
+++ b/scripts/extract_article_rulings.js
@@ -7,10 +7,10 @@ import matter from 'gray-matter';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-// Configuration
-const CASE_LAW_DIR = path.join(__dirname, 'content/Case law');
-const KEY_ARTICLES_FILE = path.join(__dirname, 'content/key-articles-by-case.md');
-const OUTPUT_FILE = path.join(__dirname, 'content/article-rulings.md');
+// Configuration (one level up from scripts/)
+const CASE_LAW_DIR = path.join(__dirname, '..', 'content', 'Case law');
+const KEY_ARTICLES_FILE = path.join(__dirname, '..', 'content', 'key-articles-by-case.md');
+const OUTPUT_FILE = path.join(__dirname, '..', 'content', 'article-rulings.md');
 
 // Debug flag
 const DEBUG = true;
@@ -199,8 +199,10 @@ async function extractArticleRulings() {
 
                 // Also check ruling-articles if available
                 if (data['ruling-articles'] && Array.isArray(data['ruling-articles'])) {
-                    debugLog(`Ruling-articles field found: ${data['ruling-articles'].join(', ')}`);
-                    data['ruling-articles'].forEach(article => {
+                    // Flatten in case [[Article X]] was parsed as nested arrays by YAML
+                    const flatRulingArticles = data['ruling-articles'].flat(Infinity).map(String);
+                    debugLog(`Ruling-articles field found: ${flatRulingArticles.join(', ')}`);
+                    flatRulingArticles.forEach(article => {
                         const articleMatch = article.match(/Article\s+(\d+)/i);
                         if (articleMatch) {
                             const num = articleMatch[1];

--- a/scripts/extract_case_articles.cjs
+++ b/scripts/extract_case_articles.cjs
@@ -2,8 +2,8 @@ const fs = require('fs');
 const path = require('path');
 const yaml = require('js-yaml');
 
-// Directory containing case law files
-const caseDir = path.join(__dirname, 'content', 'Case law');
+// Directory containing case law files (one level up from scripts/)
+const caseDir = path.join(__dirname, '..', 'content', 'Case law');
 
 // Function to convert case number to filename format (replacing / with -)
 function caseNumberToFilename(caseNumber) {
@@ -85,8 +85,8 @@ async function processFiles() {
 
         if (!metadata['case-number']) continue;
 
-        // Extract case number and normalize format
-        const caseNumber = metadata['case-number'];
+        // Extract case number and normalize format (coerce to string for safety)
+        const caseNumber = String(metadata['case-number']);
 
         // Extract parties
         let parties = metadata.parties || '';

--- a/scripts/generate-case-grid.js
+++ b/scripts/generate-case-grid.js
@@ -7,9 +7,9 @@ import matter from 'gray-matter';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-// Configuration
-const CASE_LAW_DIR = path.join(__dirname, 'content/Case law');
-const OUTPUT_FILE = path.join(__dirname, 'content/case-law-grid.md');
+// Configuration (one level up from scripts/)
+const CASE_LAW_DIR = path.join(__dirname, '..', 'content', 'Case law');
+const OUTPUT_FILE = path.join(__dirname, '..', 'content', 'case-law-grid.md');
 
 // Function to extract frontmatter from markdown files
 async function extractCaseData() {

--- a/scripts/process_article_refs.cjs
+++ b/scripts/process_article_refs.cjs
@@ -1,9 +1,9 @@
 const fs = require('fs');
 const path = require('path');
 
-// Directory containing content
-const contentDir = path.join(__dirname, 'content');
-const backupDir = path.join(__dirname, 'backup_content');
+// Directory containing content (one level up from scripts/)
+const contentDir = path.join(__dirname, '..', 'content');
+const backupDir = path.join(__dirname, '..', 'backup_content');
 
 // Create backup directory if it doesn't exist
 if (!fs.existsSync(backupDir)) {


### PR DESCRIPTION
## Summary

This PR fixes critical YAML parsing issues where wiki-link brackets (`[[Article X]]`) in frontmatter fields were being incorrectly interpreted as nested arrays, causing type errors in downstream scripts. The changes include comprehensive documentation updates, defensive code fixes, and path resolution corrections.

## Key Changes

### Documentation Updates
- **frontmatter-readme.md**: Added explicit warnings and examples clarifying that `ruling-articles` and `per-article` fields must use plain `Article X` format, never `[[Article X]]`
  - Explained why: YAML interprets `[[...]]` as flow sequences (nested arrays), breaking `.match()` and `.replace()` calls
  - Added requirement that `per-article` entries must be quoted strings to prevent the pipe character (`|`) from being misinterpreted as a YAML block scalar indicator
  - Added new "Special Formatting Notes" section documenting wiki-link bracket restrictions

- **functions-readme.md**: 
  - Clarified path resolution: all scripts in `scripts/` resolve paths relative to project root using `path.join(__dirname, '..')`
  - Updated script execution examples to show correct invocation from project root
  - Added "Frontmatter Compatibility" section referencing the wiki-link bracket restrictions

### Code Fixes
- **extract_key_articles.cjs**: Added defensive flattening and string coercion for `ruling-articles` to handle malformed nested arrays
- **scripts/extract_article_rulings.js**: 
  - Fixed path resolution (added `..` to reach content directory from scripts/)
  - Added flattening logic for `ruling-articles` field
- **scripts/extract_case_articles.cjs**: Fixed path resolution and added string coercion for `case-number`
- **scripts/generate-case-grid.js**: Fixed path resolution
- **scripts/process_article_refs.cjs**: Fixed path resolution

## Notable Implementation Details

- All path fixes follow the pattern: `path.join(__dirname, '..', 'content', ...)` for scripts in `scripts/` directory
- Defensive `.flat(Infinity).map(String)` pattern used to safely handle both correctly-formatted arrays and malformed nested arrays from YAML parsing
- Documentation now explicitly warns against wiki-link brackets in YAML frontmatter while clarifying they remain valid in markdown body content

https://claude.ai/code/session_01QYdtG5VMZMJJ5YKwatZ3Cz

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to documentation and offline utility scripts, with low blast radius; main risk is incorrect path updates breaking script execution if assumptions about repo layout differ.
> 
> **Overview**
> Resolves YAML-frontmatter parsing breakages caused by `[[Article X]]` wiki-link brackets being interpreted as nested arrays, and documents the required plain-text `Article X`/quoted `per-article` formats.
> 
> Updates multiple content-generation scripts to (a) resolve `content/` paths correctly from within `scripts/` and (b) defensively handle malformed frontmatter by flattening/coercing `ruling-articles` (and coercing `case-number`) before regex/string operations, preventing downstream type errors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5f5d89ca45f140fd07a17fff8286e777726e48ce. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->