### PR TITLE
Add comprehensive data schema documentation for database migration

### DIFF
--- a/DATA-OVERVIEW.md
+++ b/DATA-OVERVIEW.md
@@ -1,0 +1,97 @@
+# GDPRed Data Overview
+
+## What the site is
+
+A knowledge base of CJEU court judgments that interpret the GDPR. ~99 cases, 99 GDPR articles, and a handful of navigation pages.
+
+---
+
+## The data
+
+### GDPR Articles
+
+There are 99 articles (Article 1 through Article 99), one file each. Each has:
+
+- **title** — `Article 17`
+- **subtitle** — `Right to erasure ('right to be forgotten')`
+- **body** — the full regulatory text from Regulation (EU) 2016/679
+
+Articles are static reference content. They don't change. The interesting thing about an article page is the reverse lookup: which cases interpret it? That's computed from the cases' `ruling-articles` field (see below).
+
+### Cases
+
+Each case is a CJEU judgment. ~99 cases currently. Each has:
+
+- **case-number** — `C-492/23` (the official court reference)
+- **title** — usually identical to case-number
+- **date** — judgment date (e.g. `2023-06-15`)
+- **parties** — `Digi Távközlési és Szolgáltató Kft. v Nemzeti Adatvédelmi és Információszabadság Hatóság`
+- **ruling-articles** — which GDPR articles this case interprets: `["Article 5", "Article 17", "Article 24"]`. This is the core cross-reference in the system.
+- **topics** — free-text labels from the court's own tagging, 3–9 per case: `["Purpose limitation", "Storage limitation", "Data breach"]`. No controlled vocabulary — same concept appears worded differently across cases.
+- **final-ruling** — the court's actual judgment, numbered paragraphs: `**1.** Article 17 must be interpreted as meaning that...`
+- **per-article** — pipe-delimited pairs linking a specific article to what the case says about it: `Article 5 | Storage limitation requires...`. Can include sub-paragraphs like `Article 2(c)`.
+- **body** — full ruling text (~300 lines), converted from EUR-Lex HTML to markdown. Contains the procedural history, legal analysis, and ruling.
+- **aliases** — alternative case numbers for joined/related cases (rare): `["C-17/22"]`
+
+Optional enrichment fields (from a separate JSON import, not all cases have these):
+- **celex-id** — EUR-Lex identifier: `62023CJ0492`
+- **gdpr-summary** — prose summary of GDPR implications
+- **operative-parts-structured** — the ruling's numbered paragraphs broken into: verbatim text, simplified text, which articles each part interprets, which regulations it mentions
+
+Cases link to articles and to other cases via `[[wikilinks]]` in their body text. These links power backlinks and the graph visualization.
+
+### Topic taxonomy
+
+Separate from the `topics` field on cases. This is a manually curated three-level browsing structure maintained in a markdown page ("Browse by topic"):
+
+- 14 categories (e.g. "Data subject rights", "Remedies, liability, compensation")
+- ~60 subtopics under them (e.g. "Right to erasure", "Right of access")
+- Each subtopic maps to specific cases via wikilinks
+
+A partial version (3 categories, 11 subtopics) is also hardcoded in the TopicExplorer component with explicit case slugs.
+
+### Navigation pages
+
+A handful of index/browse pages:
+- Homepage — FAQ + a timeline visualization (generated HTML from all cases grouped by month)
+- Case grid — card layout of all cases (generated HTML)
+- Browse by topic — the taxonomy above
+- Cross-reference indexes — "cases by article" and "articles by case" (generated markdown)
+
+These pages use `tags: ["hidden"]` to exclude themselves from listings.
+
+---
+
+## Where the data comes from
+
+**SPARQL endpoint** (EU Publications Office) — discovers new cases. Provides: case number, date, parties, and article references (in a coded format like `A04P4` → Article 4).
+
+**EUR-Lex HTML** — the full ruling text. Downloaded per case. From the HTML we extract:
+- The ruling text → converted to markdown body
+- The final-ruling section → from specific CSS-classed elements
+- Topics → from the `C71Indicateur` element, split on dashes
+- Ruling-articles → regex `Article N` on the ruling text, merged with SPARQL data
+- Per-article interpretations → ruling paragraphs matched to article numbers
+
+**JSON metadata** (optional) — an external file with enriched data: CELEX IDs, summaries, structured operative parts. Applied as a post-processing step.
+
+**Manual content** — the 99 article pages, the topic taxonomy, and navigation pages are authored by hand.
+
+---
+
+## How data is used on the site
+
+| What a user sees | Data involved |
+|-----------------|---------------|
+| Case page header | case-number, parties, date |
+| "Articles referenced" chips on a case page | ruling-articles → links to article pages |
+| "Cases referencing this article" on an article page | reverse lookup of ruling-articles across all cases |
+| Backlinks section | wikilinks in body text (cases link to articles, cases link to cases) |
+| Graph visualization | all pages as nodes, wikilinks as directed edges |
+| Full-text search | title + plain-text body + tags, client-side |
+| Timeline on homepage | date, case-number, parties, topics for all cases |
+| Case grid | date, case-number, parties, topics for all cases |
+| Topic explorer | hardcoded mapping of categories → subtopics → cases |
+| Browse by topic | curated markdown with wikilinks to cases |
+| Sidebar file tree | all page slugs + titles |
+| Reading time | word count of body text |

--- a/DATA-SCHEMA-MAP.md
+++ b/DATA-SCHEMA-MAP.md
@@ -1,600 +1,957 @@
 # GDPRed Data Schema Map
 
-> Complete mapping of every data field, its origin, processing, and usage.
-> Use this as the definitive reference for recreating the GDPRed pipeline without Quartz.
+> Domain-focused mapping of every entity, field, relationship, and query in GDPRed.
+> Written for someone designing a database backend to replace the flat-file Quartz system.
 
 ---
 
 ## Table of Contents
 
-1. [Architecture Overview](#1-architecture-overview)
-2. [External Data Sources](#2-external-data-sources)
-3. [Content Entities](#3-content-entities)
-4. [Table A: Case Law Frontmatter Fields](#table-a-case-law-frontmatter-fields)
-5. [Table B: Article Frontmatter Fields](#table-b-article-frontmatter-fields)
-6. [Table C: General/Index Page Frontmatter Fields](#table-c-generalindex-page-frontmatter-fields)
-7. [Table D: Quartz-Internal VFile Data (QuartzPluginData)](#table-d-quartz-internal-vfile-data-quartzplugindata)
-8. [Table E: Global Configuration Fields](#table-e-global-configuration-fields)
-9. [Table F: Content Index (Search/Graph Payload)](#table-f-content-index-searchgraph-payload)
-10. [Table G: Pipeline Script I/O](#table-g-pipeline-script-io)
-11. [Table H: Component Data Consumption](#table-h-component-data-consumption)
-12. [Table I: Frontmatter Alias Resolution](#table-i-frontmatter-alias-resolution)
-13. [Table J: Output Artifacts](#table-j-output-artifacts)
-14. [Data Flow Diagram](#data-flow-diagram)
-15. [Cross-Reference Systems](#cross-reference-systems)
+1. [Domain Overview](#1-domain-overview)
+2. [Entity: Cases](#2-entity-cases)
+3. [Entity: GDPR Articles](#3-entity-gdpr-articles)
+4. [Entity: Topics](#4-entity-topics)
+5. [Entity: Topic Taxonomy](#5-entity-topic-taxonomy)
+6. [Entity: Operative Parts (structured rulings)](#6-entity-operative-parts)
+7. [Entity: Per-Article Interpretations](#7-entity-per-article-interpretations)
+8. [Entity: Pages (general content)](#8-entity-pages)
+9. [Relationship Map](#9-relationship-map)
+10. [All Queries the UI Actually Runs](#10-all-queries-the-ui-actually-runs)
+11. [Data Ingestion Pipeline](#11-data-ingestion-pipeline)
+12. [Full-Text Search and Graph Data](#12-full-text-search-and-graph-data)
+13. [Suggested Database Schema](#13-suggested-database-schema)
+14. [Appendix: Quartz Build-Time Computed Fields](#appendix-quartz-build-time-computed-fields)
+15. [Appendix: Data Flow Diagram](#appendix-data-flow-diagram)
 
 ---
 
-## 1. Architecture Overview
+## 1. Domain Overview
 
-GDPRed is a GDPR case-law knowledge base. Data flows through four phases:
+GDPRed is a legal research tool for EU GDPR case law. It has three core domain entities and several junction/child entities:
 
-```
-Phase 1: DISCOVERY     SPARQL endpoint -> new-cases.json
-Phase 2: DOWNLOAD      EUR-Lex HTML -> downloaded/*.html
-Phase 3: ASSEMBLY      HTML -> Markdown + YAML frontmatter -> content/Case law/*.md
-Phase 4: BUILD         Quartz pipeline: Parse -> Transform -> Filter -> Emit -> Static site
-```
+| Entity | What it is | Count | Example |
+|--------|-----------|-------|---------|
+| **Case** | A CJEU court judgment interpreting the GDPR | ~99 | C-492/23 |
+| **GDPR Article** | One of the 99 articles of Regulation 2016/679 | 99 | Article 17 (Right to erasure) |
+| **Topic** | A legal concept/subject that a case addresses | ~200 unique | "Purpose limitation", "Door-to-door preaching" |
+| **Topic Category** | A curated grouping of topics for browsing | 14 | "Data subject rights" |
+| **Operative Part** | A numbered paragraph of the court's ruling | 1-5 per case | "**1.** Article 17 must be interpreted..." |
+| **Per-Article Interpretation** | What a case says about a specific article | 1-10 per case | "Article 5 \| Storage limitation requires..." |
+| **Page** | Non-case/non-article content (index, browse pages) | ~10 | Welcome page, Browse by topic |
+| **Link** | A directional reference between any two pages | ~500+ | Case C-60/22 links to Article 17 |
 
-### Key Source Files
-
-| Concern | File(s) |
-|---------|---------|
-| Pipeline orchestrator | `scripts/pipeline/run-pipeline.js` |
-| Case discovery | `scripts/pipeline/sparql-discover.js` |
-| HTML download | `scripts/pipeline/fetch-html.js` |
-| Case assembly | `scripts/pipeline/assemble-case.js` |
-| Frontmatter generation | `scripts/pipeline/generate-frontmatter.js` |
-| HTML-to-Markdown | `scripts/html-to-md.cjs` |
-| VFile data types | `quartz/plugins/vfile.ts` |
-| Frontmatter parser | `quartz/plugins/transformers/frontmatter.ts` |
-| Link processing | `quartz/plugins/transformers/links.ts` |
-| Date processing | `quartz/plugins/transformers/lastmod.ts` |
-| TOC generation | `quartz/plugins/transformers/toc.ts` |
-| OFM (wikilinks) | `quartz/plugins/transformers/ofm.ts` |
-| Description extraction | `quartz/plugins/transformers/description.ts` |
-| Content index emitter | `quartz/plugins/emitters/contentIndex.ts` |
-| Global config types | `quartz/cfg.ts` |
-| Plugin types | `quartz/plugins/types.ts` |
-| Component types | `quartz/components/types.ts` |
-| Build orchestration | `quartz/build.ts` |
+The central relationship is **Cases interpret Articles**. Everything else serves navigation and discovery around that core.
 
 ---
 
-## 2. External Data Sources
+## 2. Entity: Cases
 
-### 2a. SPARQL Publications Office
+**Current storage:** `content/Case law/*.md` (one file per case, YAML frontmatter + markdown body)
+
+### Fields
+
+| Field | Type | Nullable | Example Value | Origin | What it represents |
+|-------|------|----------|---------------|--------|--------------------|
+| `case-number` | string | No | `C-492/23` | SPARQL `caseNumber` field | Official ECJEU case reference number. Format: `C-{number}/{year}` |
+| `title` | string | No | `C-492/23` | Defaults to `case-number` | Display title, usually identical to case-number |
+| `date` | date | No | `2023-06-15` | SPARQL `caseDate` | Date of the court's judgment (not filing date) |
+| `parties` | string | No | `Digi Távközlési és Szolgáltató Kft. v Nemzeti Adatvédelmi és Információszabadság Hatóság` | SPARQL `caseParties` | Plaintiff v Defendant, often with long institutional names |
+| `topics` | string[] | No | `["Purpose limitation", "Storage limitation", "Data breach", "Database management"]` | EUR-Lex HTML `C71Indicateur` element | 3-9 legal concepts the case addresses. Highly variable specificity (see below) |
+| `final-ruling` | text | Yes | `**1.** Article 3(2) of Directive 95/46/EC... must be interpreted as meaning that...` `**2.** Article 2(c)...` | EUR-Lex HTML between classes `C41DispositifIntroduction` and `C77Signatures` | The court's actual judgment, numbered paragraphs with bold numbering |
+| `ruling-articles` | string[] | No | `["Article 2", "Article 4", "Article 5", "Article 12", "Article 17"]` | Merged: SPARQL `modifiedLocations` + regex `Article (\d+)` on ruling text | GDPR articles this case interprets. This is **the primary cross-reference** |
+| `per-article` | string[] | Yes | `["Article 5 \| Interpretation from final ruling related to Article 5", "Article 6 \| Interpretation from..."]` | `generate-frontmatter.js` maps ruling paragraphs to articles | Pipe-delimited pairs: `Article N \| ruling excerpt`. See entity 7 |
+| `aliases` | string[] | Yes | `["C-17/22"]` | Manual entry for joined/related cases | Alternative case numbers that should redirect to this page |
+| `celex-id` | string | Yes | `62023CJ0492` | `apply_json_frontmatter.js` from JSON | EUR-Lex CELEX identifier for linking back to source |
+| `gdpr-summary` | string | Yes | (prose summary) | `apply_json_frontmatter.js` from JSON | Human-readable summary of GDPR implications |
+| `operative_parts_structured` | object[] | Yes | (see entity 6) | `apply_json_frontmatter.js` from JSON | Structured breakdown of ruling paragraphs |
+| `body` | text (markdown) | No | Full court judgment (~300 lines, starting with `JUDGMENT OF THE COURT...`) | EUR-Lex HTML converted via Turndown | Complete ruling text: header, procedural history, legal analysis, ruling |
+
+### About the `topics` field — real examples showing variability
+
+```yaml
+# Case C-25/17 — 8 topics, mix of broad and narrow:
+topics:
+  - Protection of personal data
+  - Processing of personal data
+  - Religious community activities
+  - Door-to-door preaching
+  - Filing system
+  - Data controller responsibilities
+  - Scope of data protection directive
+  - Joint controllership
+
+# Case C-77/21 — 4 topics, more focused:
+topics:
+  - Purpose limitation
+  - Storage limitation
+  - Data breach
+  - Database management
+
+# Case C-422/24 — 6 topics, one very long:
+topics:
+  - Protection of personal data
+  - Regulation (EU) 2016/679
+  - "Articles 13 and 14"
+  - Scope
+  - Personal data collected by means of body cameras worn by ticket inspectors on public transport
+  - Legal basis for the obligation on the data controller to provide information to the data subject
+```
+
+Topics are free-text with no controlled vocabulary. The same concept appears differently across cases (e.g. "Protection of personal data" vs "Protection of natural persons with regard to the processing of personal data"). Range: 3-9 per case.
+
+### About the `date` field — format inconsistency
+
+The date field has three formats in existing data:
+- `2018-07-10` (plain date)
+- `2022-10-20T00:00:00.000Z` (ISO with time)
+- `'2025-12-18'` (quoted string)
+
+All represent the judgment date. A database should normalize to a DATE column.
+
+---
+
+## 3. Entity: GDPR Articles
+
+**Current storage:** `content/Articles/Article N.md` (one file per article)
+
+### Fields
+
+| Field | Type | Nullable | Example Value | What it represents |
+|-------|------|----------|---------------|--------------------|
+| `article_number` | integer | No | `17` | The article number (1-99) of Regulation (EU) 2016/679 |
+| `title` | string | No | `Article 17` | Display title |
+| `subtitle` | string | No | `Right to erasure ('right to be forgotten')` | Human-readable name of the article's subject |
+| `body` | text (markdown) | No | `## Right to erasure...\n\n1. The data subject shall have the right...` | The full regulatory text with numbered paragraphs and lettered sub-items |
+
+### Example body content (Article 5)
+
+```markdown
+## Principles relating to processing of personal data
+
+1. Personal data shall be:
+
+(a) processed lawfully, fairly and in a transparent manner...
+    ('lawfulness, fairness and transparency');
+
+(b) collected for specified, explicit and legitimate purposes...
+    ('purpose limitation');
+
+(c) adequate, relevant and limited to what is necessary...
+    ('data minimisation');
+
+2. The controller shall be responsible for, and be able to demonstrate
+   compliance with, paragraph 1 ('accountability').
+```
+
+Article pages are **reference documents** — their content is static regulatory text. The dynamic part is the reverse-lookup: "which cases interpret this article?"
+
+---
+
+## 4. Entity: Topics
+
+Topics are free-text labels attached to cases. They are **not** the same as the curated topic taxonomy (section 5).
+
+**Current storage:** YAML array in each case's frontmatter (`topics:`)
+
+### Fields
+
+| Field | Type | Nullable | Example Value |
+|-------|------|----------|---------------|
+| `topic_text` | string | No | `Purpose limitation` |
+
+There are roughly **200 unique topic strings** across all cases. Many are near-duplicates. They come directly from the court's own tagging (the `C71Indicateur` HTML element).
+
+In a database, these would be a separate table with a many-to-many junction to cases:
+
+```
+cases ←→ case_topics ←→ topics
+```
+
+---
+
+## 5. Entity: Topic Taxonomy
+
+The "Browse by topic" page contains a **manually curated** 14-category taxonomy mapping topics to cases. This is separate from the `topics` frontmatter array.
+
+**Current storage:** Two places:
+1. `content/Browse by topic.md` — markdown with wikilinks (the authoritative source)
+2. `quartz/components/pages/TopicExplorer.tsx` — hardcoded subset (3 categories, 11 subtopics, 25 cases)
+
+### The 14 categories (from Browse by topic.md)
+
+| # | Category | Example subtopics | Cases referenced |
+|---|----------|--------------------|-----------------|
+| 1 | Definitions and scope | Definition of 'personal data', Concept of 'controller' | C-579-21, C-487-21, C-231-22, C-272-19, C-807-21, C-461-22, C-60-22, C-659-22 |
+| 2 | Principles of processing | General principles, Purpose limitation, Data minimisation, Storage limitation | C-340-21, C-60-22, C-205-21, C-394-23, C-446-21, C-77-21 |
+| 3 | Lawfulness of processing | Conditions, Consent, Legitimate interests | C-175-20, C-205-21, C-306-21, C-34-21, C-394-23, C-60-22, C-621-22, C-180-21, C-667-21, C-673-17, C-61-19, C-129-21, C-604-22 |
+| 4 | Controllers, joint controllers, processors | Controllership, Joint control, Subsequent processing | C-60-22, C-461-22, C-604-22, C-683-21, C-231-22, C-180-21 |
+| 5 | Data subject rights | Access, Erasure, Object, Restriction | C-272-19, C-307-22, C-487-21, C-757-22, C-169-23, C-579-21, C-461-22, C-245-20, C-394-23, C-60-22, C-129-21, C-200-23, C-231-22 |
+| 6 | Controller obligations | Transparency, Records, Security, DPO, Liability | C-757-22, C-60-22, C-340-21, C-687-21, C-453-21, C-741-21 |
+| 7 | Data breaches | Breach management, Security measures | C-77-21, C-340-21, C-687-21 |
+| 8 | Special categories of data | Biometric, Health, Criminal | C-205-21, C-21-23, C-667-21, C-446-21, C-439-19, C-394-23 |
+| 9 | Specific processing contexts | Employment, Medical, Credit agencies, Online | C-65-23, C-34-21, C-667-21, C-307-22, C-61-19, C-496-17, C-634-21, C-659-22, C-579-21, C-60-22, C-394-23, C-456-22, C-740-22, C-817-19, C-446-21, C-621-22, C-306-21 |
+| 10 | Cross-border data transfers | Third countries, Standard clauses, One-stop shop | C-311-18, C-645-19 |
+| 11 | Supervisory authorities | Competence, Discretion, Fines, Complaints | C-33-22, C-169-23, C-245-20, C-807-21, C-768-21, C-416-23, C-683-21, C-590-22 |
+| 12 | Remedies, liability, compensation | Right to compensation, Damage concept, Non-material damage | C-300-21, C-340-21, C-456-22, C-507-23, C-667-21, C-687-21, C-741-21, C-590-22, C-200-23, C-132-21, C-21-23, C-757-22 |
+| 13 | Procedural and jurisdictional | TFEU, Primacy of EU law, Proportionality | C-439-19, C-272-19, C-579-21, C-132-21, C-507-23, C-300-21, C-687-21, C-645-19, C-175-20, C-461-22, C-205-21, C-180-21 |
+| 14 | Interaction with other frameworks | Consumer protection, Competition, COVID, National security | C-21-23, C-319-20, C-757-22, C-252-21, C-129-21, C-169-23, C-659-22, C-184-20, C-33-22, C-817-19 |
+
+### Structure
+
+This is a three-level hierarchy:
+```
+Topic Category (14)
+  └── Topic Subtopic (~60 distinct subtopics)
+        └── Case references (many-to-many)
+```
+
+The TopicExplorer component has a **hardcoded subset** of only 3 categories with 25 cases mapped by slug:
+
+```typescript
+// From TopicExplorer.tsx — entirely hardcoded, not driven by data
+"Data processing principles": {
+    "Lawfulness of processing": caseFiles.filter(f =>
+        f.slug?.includes("C-175-20") || f.slug?.includes("C-205-21") || ...
+    ),
+    "Data minimization": caseFiles.filter(f => ...),
+    ...
+},
+"Controllers and processors": { ... },
+"Data subject rights": { ... }
+```
+
+In a database, this mapping should be a proper data structure, not hardcoded.
+
+---
+
+## 6. Entity: Operative Parts
+
+Optional structured breakdown of the ruling's numbered paragraphs, enriched from external JSON.
+
+**Current storage:** YAML object array in case frontmatter (`operative_parts_structured:`)
+**Origin:** `apply_json_frontmatter.js` reads from `case-metadata.json`
+
+### Fields
+
+| Field | Type | Nullable | Example |
+|-------|------|----------|---------|
+| `case_number` | string (FK) | No | `C-492/23` |
+| `number` | integer | No | `1` |
+| `verbatim` | text | No | The exact text from the court ruling |
+| `simplified` | text | Yes | A simplified/summarized version |
+| `interprets_articles` | integer[] | Yes | `[4, 5, 12]` — which GDPR article numbers this part interprets |
+| `mentions_regulations` | string[] | Yes | `["Regulation (EU) 2016/679", "Directive 95/46/EC"]` |
+
+**Not currently consumed by any UI component** — this is stored metadata for potential future use.
+
+---
+
+## 7. Entity: Per-Article Interpretations
+
+What a specific case says about a specific article, extracted from the ruling text.
+
+**Current storage:** YAML string array in case frontmatter (`per-article:`)
+
+### Raw format
+
+```yaml
+per-article:
+  - "Article 2(c) | Article 2(c) of Directive 95/46 must be interpreted as meaning that
+     the concept of a 'filing system'... covers a set of personal data collected in the
+     course of door-to-door preaching..."
+  - "Article 2(d) | Article 2(d) of Directive 95/46, read in the light of Article 10(1)
+     of the Charter... must be interpreted as meaning that..."
+```
+
+### Normalized fields
+
+| Field | Type | Example |
+|-------|------|---------|
+| `case_number` | string (FK) | `C-25/17` |
+| `article_reference` | string | `Article 2(c)` — note: includes sub-paragraph |
+| `interpretation_text` | text | `Article 2(c) of Directive 95/46 must be interpreted as meaning that the concept of a 'filing system'...` |
+
+This is a **junction entity** between Cases and Articles, carrying the interpretation as payload. Note that `article_reference` can include sub-paragraphs (`Article 2(c)`) not just article numbers.
+
+---
+
+## 8. Entity: Pages (general content)
+
+Non-case, non-article pages for navigation and presentation.
+
+**Current storage:** `content/*.md` and `content/` subdirectory index files
+
+### Fields
+
+| Field | Type | Nullable | Example |
+|-------|------|----------|---------|
+| `slug` | string | No | `index`, `Browse-by-topic`, `case-law-grid` |
+| `title` | string | No | `Welcome!`, `Browse by topic`, `Case Law Overview` |
+| `subtitle` | string | Yes | Descriptive subtitle |
+| `tags` | string[] | Yes | `["hidden"]` — used to exclude from listings |
+| `cssclasses` | string[] | Yes | `["no-date", "no-title"]` — presentation hints |
+| `body` | text (markdown/HTML) | No | Page content, may include embedded HTML (timeline, grid) |
+
+### Known pages and their purpose
+
+| Page | Purpose | Data it embeds |
+|------|---------|---------------|
+| `index.md` | Homepage with FAQ, timeline visualization | Timeline HTML generated from all cases |
+| `Browse by topic.md` | The 14-category topic taxonomy | Wikilinks to cases organized by topic |
+| `case-law-grid.md` | Card grid of all cases | Generated HTML cards with case-number, parties, date, topics |
+| `Case law by CJEU-topics.md` | Raw court topics listing | Reference for the court's own tagging |
+| `cases_by_article.md` | Cross-reference: per case, its articles | Generated by `extract_case_articles.cjs` |
+| `articles_by_case.md` | Cross-reference: per article, its cases | Generated by `extract_case_articles.cjs` |
+
+---
+
+## 9. Relationship Map
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                          DOMAIN RELATIONSHIPS                          │
+│                                                                        │
+│  ┌──────────┐                                       ┌──────────────┐  │
+│  │  Cases    │──────── ruling_articles (M:N) ───────│ GDPR Articles│  │
+│  │          │         (the core relationship)       │              │  │
+│  │ C-492/23 │                                       │ Article 17   │  │
+│  │ C-77/21  │──┐                                    │ Article 5    │  │
+│  │ C-25/17  │  │                                    │ ...          │  │
+│  └─────┬────┘  │                                    └──────────────┘  │
+│        │       │                                                      │
+│        │       │  per_article_interpretations (1:N from case)         │
+│        │       └──── "Article 5 | Storage limitation requires..."     │
+│        │             "Article 6 | Interpretation from ruling..."      │
+│        │                                                              │
+│        │       ┌──────────────────┐                                   │
+│        ├───────│  Topics (M:N)    │  Free-text, from court tagging    │
+│        │       │ "Purpose limit." │                                   │
+│        │       │ "Data breach"    │                                   │
+│        │       └──────────────────┘                                   │
+│        │                                                              │
+│        │       ┌──────────────────────────────┐                       │
+│        ├───────│  Operative Parts (1:N)       │  Structured ruling    │
+│        │       │ { number: 1, verbatim: "..." │  paragraphs           │
+│        │       │   simplified: "...",         │  (from JSON enrichment│
+│        │       │   interprets_articles: [4,5] │   optional)           │
+│        │       │ }                            │                       │
+│        │       └──────────────────────────────┘                       │
+│        │                                                              │
+│        │       ┌──────────────────────────────┐                       │
+│        └───────│  Links (directed, M:N)       │  Wikilinks in body    │
+│                │ C-60/22 → Article 17         │  text. Used for       │
+│                │ C-60/22 → C-231/22           │  backlinks + graph    │
+│                │ Article 17 → C-129/21        │                       │
+│                └──────────────────────────────┘                       │
+│                                                                       │
+│  ┌──────────────────────────────────────────────────────────────────┐ │
+│  │  Topic Taxonomy (curated, separate from topics)                  │ │
+│  │                                                                  │ │
+│  │  Category ──────────── Subtopic ──────────── Cases               │ │
+│  │  "Data subject rights"  "Right to erasure"   C-129-21, C-200-23 │ │
+│  │  "Data subject rights"  "Right of access"    C-307-22, C-487-21 │ │
+│  │  "Remedies, liability"  "Compensation"       C-300-21, C-507-23 │ │
+│  │  (14 categories)        (~60 subtopics)      (~80 case refs)    │ │
+│  └──────────────────────────────────────────────────────────────────┘ │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+### Summary of relationships
+
+| Relationship | Type | From | To | Payload | How it's stored now |
+|-------------|------|------|----|---------|---------------------|
+| Case interprets Article | Many-to-many | Case | Article | -- | `ruling-articles` array in case frontmatter |
+| Case has Topic | Many-to-many | Case | Topic | -- | `topics` array in case frontmatter |
+| Case has Operative Part | One-to-many | Case | Operative Part | number, verbatim, simplified, interprets_articles, mentions_regulations | `operative_parts_structured` in frontmatter |
+| Case has Per-Article Interpretation | One-to-many | Case | Interpretation | article_ref, text | `per-article` array (pipe-delimited strings) |
+| Case aliases Case | One-to-many | Case | Alias slug | -- | `aliases` array in frontmatter |
+| Page links to Page | Many-to-many (directed) | Any page | Any page | -- | `[[wikilinks]]` in body text, extracted to `links[]` at build time |
+| Taxonomy Category has Subtopic | One-to-many | Category | Subtopic | -- | Markdown headings and bullet points in `Browse by topic.md` |
+| Taxonomy Subtopic references Case | Many-to-many | Subtopic | Case | -- | Wikilinks in `Browse by topic.md` + hardcoded slugs in `TopicExplorer.tsx` |
+
+---
+
+## 10. All Queries the UI Actually Runs
+
+These are the data lookups the components perform. In a database system, each becomes a SQL query or API endpoint.
+
+### Query 1: "Which cases cite this article?" (ArticleCases.tsx)
+
+**Triggered on:** Every Article page (e.g. `/Articles/Article-17`)
+
+```
+Current implementation:
+  1. Extract article number from current page slug via regex /article[- ](\d+)/i
+  2. Filter ALL case files where ruling-articles[] contains "Article {N}"
+  3. Sort by date descending
+  4. Return: title, date, parties for each match
+
+SQL equivalent:
+  SELECT c.case_number, c.title, c.date, c.parties
+  FROM cases c
+  JOIN case_ruling_articles cra ON c.id = cra.case_id
+  JOIN articles a ON a.id = cra.article_id
+  WHERE a.article_number = ?
+  ORDER BY c.date DESC
+```
+
+### Query 2: "What articles does this case interpret?" (NowReading.tsx)
+
+**Triggered on:** Every Case page
+
+```
+Current implementation:
+  1. Read ruling-articles[] from current page's frontmatter
+  2. Parse each entry with regex /Article\s+(\d+)/
+  3. Generate link to /Articles/Article-{N}
+
+SQL equivalent:
+  SELECT a.article_number, a.title, a.subtitle
+  FROM articles a
+  JOIN case_ruling_articles cra ON a.id = cra.article_id
+  WHERE cra.case_id = ?
+  ORDER BY a.article_number
+```
+
+### Query 3: "Who are the parties in this case?" (Parties.tsx)
+
+**Triggered on:** Every Case page
+
+```
+Current implementation:
+  Read frontmatter.parties from current page
+
+SQL equivalent:
+  SELECT parties FROM cases WHERE id = ?
+```
+
+### Query 4: "What pages link to this page?" (Backlinks.tsx)
+
+**Triggered on:** Every page
+
+```
+Current implementation:
+  Filter ALL files where their links[] array includes current page's slug
+  Return: title, parties (if case), subtitle (if article)
+
+SQL equivalent:
+  SELECT p.slug, p.title, c.parties, a.subtitle
+  FROM page_links pl
+  JOIN pages p ON p.id = pl.source_page_id
+  LEFT JOIN cases c ON c.page_id = p.id
+  LEFT JOIN articles a ON a.page_id = p.id
+  WHERE pl.target_page_id = ?
+```
+
+### Query 5: "List all cases in a topic category" (TopicExplorer.tsx)
+
+**Triggered on:** Topic explorer page
+
+```
+Current implementation:
+  HARDCODED slug matches per topic per category (25 cases across 11 subtopics)
+
+SQL equivalent:
+  SELECT tc.category_name, ts.subtopic_name, c.case_number, c.title
+  FROM taxonomy_case_refs tcr
+  JOIN taxonomy_subtopics ts ON ts.id = tcr.subtopic_id
+  JOIN taxonomy_categories tc ON tc.id = ts.category_id
+  JOIN cases c ON c.case_number = tcr.case_number
+  ORDER BY tc.sort_order, ts.sort_order, c.case_number
+```
+
+### Query 6: "List recent pages sorted by date" (RecentNotes.tsx, PageList.tsx)
+
+**Triggered on:** Homepage and folder pages
+
+```
+Current implementation:
+  Sort allFiles by date desc, then alphabetically
+  Apply optional tag filter, slice to limit (default 3)
+
+SQL equivalent:
+  SELECT title, date, slug FROM pages
+  WHERE tags NOT LIKE '%hidden%'  -- optional filter
+  ORDER BY date DESC NULLS LAST, title ASC
+  LIMIT ?
+```
+
+### Query 7: "Get the file tree" (Explorer.tsx)
+
+**Triggered on:** Every page (sidebar)
+
+```
+Current implementation:
+  Build tree from all file slugs (split on /)
+  Each node: title from frontmatter, parties as subtitle
+
+SQL equivalent:
+  SELECT slug, title,
+    CASE WHEN page_type = 'case' THEN parties ELSE subtitle END as subtitle
+  FROM pages
+  ORDER BY slug
+```
+
+### Query 8: "Full-text search" (Search.tsx, client-side)
+
+**Triggered on:** User search input
+
+```
+Current implementation:
+  FlexSearch over contentIndex.json
+  Indexes: title, content (plain text), tags
+  Returns: slug + title for top 8 matches
+
+SQL equivalent:
+  SELECT slug, title,
+    ts_rank(search_vector, plainto_tsquery(?)) as rank
+  FROM pages
+  WHERE search_vector @@ plainto_tsquery(?)
+  ORDER BY rank DESC
+  LIMIT 8
+```
+
+### Query 9: "Build the link graph" (Graph.tsx, client-side)
+
+**Triggered on:** Every page (graph panel)
+
+```
+Current implementation:
+  All nodes from contentIndex.json
+  Edges from ContentDetails.links[]
+  BFS from current page to depth N
+
+SQL equivalent:
+  -- Nodes:
+  SELECT slug, title FROM pages
+
+  -- Edges:
+  SELECT source_slug, target_slug FROM page_links
+
+  -- Neighborhood (recursive CTE):
+  WITH RECURSIVE neighborhood AS (
+    SELECT target_slug, 1 as depth FROM page_links WHERE source_slug = ?
+    UNION
+    SELECT pl.target_slug, n.depth + 1
+    FROM page_links pl JOIN neighborhood n ON pl.source_slug = n.target_slug
+    WHERE n.depth < ?
+  )
+  SELECT DISTINCT * FROM neighborhood
+```
+
+### Query 10: "Get pages by tag" (TagContent.tsx)
+
+```
+Current implementation:
+  Filter allFiles where frontmatter.tags includes requested tag
+  Only ~5 pages actually use tags (index pages with tag "hidden")
+
+SQL equivalent:
+  SELECT p.slug, p.title, p.date
+  FROM pages p
+  JOIN page_tags pt ON p.id = pt.page_id
+  JOIN tags t ON t.id = pt.tag_id
+  WHERE t.slug = ?
+```
+
+### Query 11: "Timeline data" (generated into index.md)
+
+```
+Current implementation:
+  generate-timeline.js reads all case .md files
+  Groups by month+year, sorts desc
+
+SQL equivalent:
+  SELECT case_number, date, parties, topics,
+    TO_CHAR(date, 'Month') as month, EXTRACT(YEAR FROM date) as year
+  FROM cases
+  WHERE date IS NOT NULL AND parties IS NOT NULL
+  ORDER BY date DESC
+```
+
+### Query 12: "Case grid data" (generated into case-law-grid.md)
+
+```
+Current implementation:
+  generate-case-grid.js reads all case .md files
+
+SQL equivalent:
+  SELECT case_number, date, parties,
+    array_agg(t.topic_text) as topics
+  FROM cases c
+  LEFT JOIN case_topics ct ON c.id = ct.case_id
+  LEFT JOIN topics t ON t.id = ct.topic_id
+  WHERE c.date IS NOT NULL AND c.parties IS NOT NULL
+  GROUP BY c.id
+  ORDER BY c.date DESC
+```
+
+---
+
+## 11. Data Ingestion Pipeline
+
+How data enters the system, step by step.
+
+### Step 1: Discover new cases
 
 | Property | Value |
 |----------|-------|
-| **Endpoint** | `https://publications.europa.eu/webapi/rdf/sparql` |
-| **Target regulation** | Regulation (EU) 2016/679 (GDPR) |
 | **Script** | `scripts/pipeline/sparql-discover.js` |
+| **Source** | `https://publications.europa.eu/webapi/rdf/sparql` |
+| **Query target** | CELEX `32016R0679` (GDPR) cases from Court of Justice |
 
-**Fields returned per case:**
+**SPARQL fields returned:**
 
-| SPARQL Field | Type | Description | Maps to Frontmatter |
-|-------------|------|-------------|---------------------|
-| `caseCelex` | string | CELEX identifier (e.g. `62023CJ0492`) | `celex-id` (via JSON apply) |
-| `caseNumber` | string | Court case number (e.g. `Case C-492/23`) | `case-number`, `title` |
-| `caseDate` | string | Judgment date (ISO) | `date` |
-| `caseParties` | string | Parties involved | `parties` |
-| `caseShortTitle` | string | Short case title | _(used in pipeline logs)_ |
-| `caseTitle` | string | Full case title | _(used in pipeline logs)_ |
-| `modifiedLocations` | string | Article references (e.g. `A04P4, A05P2`) | `ruling-articles` (parsed) |
+| Field | Type | Example | Maps to |
+|-------|------|---------|---------|
+| `caseCelex` | string | `62023CJ0492` | `celex-id` (via JSON enrichment) |
+| `caseNumber` | string | `Case C-492/23` | `case-number` (stripped of "Case "), `title` |
+| `caseDate` | string | `2023-06-15` | `date` |
+| `caseParties` | string | `Company v Authority` | `parties` |
+| `modifiedLocations` | string | `A04P4, A05P2, A24` | `ruling-articles` (parsed: `A04` → `Article 4`) |
+| `caseTitle` | string | Full title | Pipeline logs only |
+| `caseShortTitle` | string | Short title | Pipeline logs only |
 
-**Filtering logic:**
-- Excludes non-CJ cases (pending cases marked "CN")
-- Excludes joined cases (flagged for manual review)
+**Filtering:**
+- Skips pending cases (CELEX containing `CN` instead of `CJ`)
+- Skips joined cases (caseNumber containing `and` or multiple comma-separated C-numbers)
+- Skips cases already present as files in `content/Case law/`
 - Deduplicates by CELEX ID
-- Only returns cases not already in `content/Case law/`
 
-### 2b. EUR-Lex HTML Documents
+**Output:** `scripts/pipeline/new-cases.json`
+
+### Step 2: Download HTML
 
 | Property | Value |
 |----------|-------|
-| **URL pattern** | `https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:{caseCelex}` |
 | **Script** | `scripts/pipeline/fetch-html.js` |
-| **Rate limit** | 2 seconds between requests |
-| **Retry** | 3 attempts, exponential backoff (2s -> 4s -> 8s) |
-| **User-Agent** | `GDPRed-Pipeline/1.0` |
+| **URL pattern** | `https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:{caseCelex}` |
+| **Rate limit** | 2s between requests |
 | **Output** | `scripts/pipeline/downloaded/{caseCelex}.html` |
 
-**Data extracted from HTML** (by `generate-frontmatter.js`):
-
-| HTML Structure | CSS Class / Pattern | Extracted As |
-|---------------|-------------------|-------------|
-| Final ruling text | Between `C41DispositifIntroduction` and `C77Signatures` | `final-ruling` |
-| Topic indicators | `C71Indicateur` paragraph, split on `--` / `--` | `topics` array |
-| Article references | `Article N` patterns (N = 1-99) in ruling text | `ruling-articles` array |
-| Per-article rulings | Ruling paragraphs matched to article numbers | `per-article` array |
-| Full document body | Entire HTML content | Markdown body (via Turndown) |
-
-### 2c. External JSON Metadata (optional enrichment)
+### Step 3: Extract frontmatter from HTML
 
 | Property | Value |
 |----------|-------|
-| **File** | `case-metadata.json` (local) |
+| **Script** | `scripts/pipeline/generate-frontmatter.js` |
+| **Input** | Case data object + raw HTML |
+
+**Extraction logic by field:**
+
+| Field | HTML selector / pattern | Transformation |
+|-------|------------------------|----------------|
+| `final-ruling` | Text between `C41DispositifIntroduction` and `C77Signatures` class elements | Paragraphs joined with `\n\n`, numbered points prefixed with `**N.**` |
+| `topics` | `C71Indicateur` class paragraphs | Split on ` -- ` or ` – `, filter out "Reference for a preliminary ruling", trim |
+| `ruling-articles` (from HTML) | Regex `\bArticle\s+(\d+)` on final-ruling text | Filter to 1-99, format as `Article N` |
+| `ruling-articles` (from SPARQL) | `modifiedLocations` string `A04P4, A05P2` | Regex `A(\d+)` → `Article N` |
+| `ruling-articles` (merged) | Union of HTML + SPARQL sources | Sort numerically, deduplicate |
+| `per-article` | Match ruling paragraphs to article numbers | Format as `Article N \| ruling text` |
+
+### Step 4: Convert HTML body to Markdown
+
+| Property | Value |
+|----------|-------|
+| **Script** | `scripts/html-to-md.cjs` |
+| **Library** | Turndown (ATX headings, fenced code blocks) |
+
+**Post-processing:**
+- Merges orphaned numbering lines (`1.` on its own line → joined with next line)
+- Merges orphaned bullets (`*`, `•`, `–`, `—` alone on a line)
+- Normalizes paragraph spacing to exactly `\n\n`
+
+### Step 5: Assemble case file
+
+| Property | Value |
+|----------|-------|
+| **Script** | `scripts/pipeline/assemble-case.js` |
+| **Output** | `content/Case law/{case-number-with-dashes}.md` |
+
+Combines: `---\n{YAML frontmatter}\n---\n\n{markdown body}`
+
+### Step 6 (optional): Enrich from JSON
+
+| Property | Value |
+|----------|-------|
 | **Script** | `scripts/apply_json_frontmatter.js` |
+| **Input** | `case-metadata.json` |
 
-**JSON fields per case:**
+**JSON → Frontmatter mapping:**
 
-| JSON Field | Type | Maps to Frontmatter |
-|-----------|------|---------------------|
-| `caseId` | string | `case-number` |
-| `celexId` | string | `celex-id` |
-| `date` | string | `date` |
-| `parties` | string | `parties` |
-| `summary` | string | `gdpr-summary` |
-| `interpretedArticleNumbers` | number[] | `ruling-articles` (formatted as `Article N`) |
-| `operativePartsCombined` | string | `final-ruling` |
-| `operativeParts` | object[] | `operative_parts_structured` |
-| `operativeParts[].number` | number | `operative_parts_structured[].number` |
-| `operativeParts[].verbatimText` | string | `operative_parts_structured[].verbatim` |
-| `operativeParts[].simplifiedText` | string | `operative_parts_structured[].simplified` |
-| `operativeParts[].interpretedArticles` | number[] | `operative_parts_structured[].interprets_articles` |
-| `operativeParts[].regulations` | string[] | `operative_parts_structured[].mentions_regulations` |
+| JSON field | Frontmatter field | Transform |
+|-----------|-------------------|-----------|
+| `caseId` | `case-number` | Keep as-is (format: `Case C-1/17`) |
+| `caseId` | `title` | Strip `Case ` prefix |
+| `parties` | `parties` | Direct |
+| `date` | `date` | Direct |
+| `celexId` | `celex-id` | Direct |
+| `summary` | `gdpr-summary` | Direct |
+| `interpretedArticleNumbers` | `ruling-articles` | Map each number N → `Article N` |
+| `operativePartsCombined` | `final-ruling` | Direct |
+| `operativeParts[]` | `operative_parts_structured[]` | Map to `{number, verbatim, simplified, interprets_articles, mentions_regulations}` |
 
----
+### Post-processing scripts
 
-## 3. Content Entities
-
-The system has three distinct content entity types:
-
-| Entity | Location | Count | Description |
-|--------|----------|-------|-------------|
-| **Case Law** | `content/Case law/*.md` | ~99 | Individual CJEU case judgments |
-| **Articles** | `content/Articles/Article N.md` | 99 | GDPR articles (1-99) |
-| **Index/Browse Pages** | `content/*.md` | ~10 | Navigation, timelines, grids |
+| Script | Purpose | I/O |
+|--------|---------|-----|
+| `extract_case_articles.cjs` | Build cross-reference indexes | Reads all case `.md` → writes `cases_by_article.md` + `articles_by_case.md` |
+| `extract_article_rulings.js` | Index ruling text by article | Reads case `.md` → writes `article-rulings.md` |
+| `process_article_refs.cjs` | Fix invalid article refs | Finds `[[Article N]]` where N>99, replaces with plain text |
+| `generate-timeline.js` | Build timeline visualization | Reads case `.md` → injects HTML into `index.md` |
+| `generate-case-grid.js` | Build case card grid | Reads case `.md` → writes `case-law-grid.md` |
+| `check_frontmatter.js` | Validate frontmatter syntax | Reads all `.md`, reports errors, no file changes |
 
 ---
 
-## Table A: Case Law Frontmatter Fields
+## 12. Full-Text Search and Graph Data
 
-Each row is a field found in `content/Case law/*.md` files.
+### Content Index (contentIndex.json)
 
-| Field | Type | Required | Origin | Processing | Used By |
-|-------|------|----------|--------|-----------|---------|
-| `title` | string | Yes | SPARQL `caseNumber` stripped to short form (e.g. `C-492/23`) | If absent, defaults to filename stem. `generate-frontmatter.js` formats from SPARQL data. | `ArticleTitle.tsx`, `Breadcrumbs.tsx`, `PageList.tsx`, `RecentNotes.tsx`, `Backlinks.tsx`, search index, graph nodes, RSS feed |
-| `date` | string (ISO 8601) | Yes | SPARQL `caseDate` | Stored as ISO string. Quartz `lastmod.ts` coalesces `created`/`date` aliases into `dates.created`, `dates.published`. | `ContentMeta.tsx` (display), `ArticleCases.tsx` (sorting), `PageList.tsx`, `RecentNotes.tsx`, sitemap `<lastmod>`, RSS `<pubDate>` |
-| `case-number` | string | Yes | SPARQL `caseNumber`, formatted as `C-XXX/YY` | `generate-frontmatter.js` normalizes from SPARQL. `apply_json_frontmatter.js` can override from JSON. | `TopicExplorer.tsx` (categorization), case grid generation, timeline generation |
-| `parties` | string | Yes | SPARQL `caseParties` or HTML extraction | Stored as `Plaintiff v Defendant` format. | `Parties.tsx` (renders as styled h2), `Backlinks.tsx` (subtitle), `ArticleCases.tsx` (list item), timeline, case grid |
-| `topics` | string[] | Yes | EUR-Lex HTML `C71Indicateur` paragraph | `generate-frontmatter.js` splits on `--`/`--`, filters generic phrases, trims whitespace. | `TopicExplorer.tsx` (hierarchical categorization), timeline (display), case grid (display) |
-| `final-ruling` | string (multiline) | Yes | EUR-Lex HTML between `C41DispositifIntroduction` and `C77Signatures` | `generate-frontmatter.js` extracts and formats numbered points as `**1.**` prefix. YAML block scalar (`\|` or `\|-`). | Rendered in case page body. Used by `extract_article_rulings.js` to build per-article ruling index. |
-| `ruling-articles` | string[] | Yes | EUR-Lex HTML + SPARQL `modifiedLocations` | `generate-frontmatter.js` finds `Article N` patterns (1-99) in ruling text, merges with SPARQL article refs, deduplicates. Format: `Article N` with `[[` wikilink brackets. | `NowReading.tsx` (article chip links), `ArticleCases.tsx` (cross-reference filter), `extract_case_articles.cjs` (index generation) |
-| `per-article` | string[] | No | EUR-Lex HTML ruling text | `generate-frontmatter.js` maps ruling paragraphs to specific articles. Format: `Article N \| ruling text...` | Rendered in case page body for per-article breakdown |
-| `aliases` | string[] | No | Manual or auto-generated | Quartz `frontmatter.ts` coalesces `aliases`/`alias`, converts to `FullSlug[]`, pushes to `allSlugs`. | `aliases.ts` emitter creates HTML redirect pages, `allSlugs` for link resolution |
-| `celex-id` | string | No | `apply_json_frontmatter.js` from JSON `celexId` | Direct mapping from external JSON metadata. | Not consumed by any component (reference only) |
-| `gdpr-summary` | string | No | `apply_json_frontmatter.js` from JSON `summary` | Direct mapping from external JSON metadata. | Not consumed by any component (reference only) |
-| `operative_parts_structured` | object[] | No | `apply_json_frontmatter.js` from JSON `operativeParts` | Structured array with `number`, `verbatim`, `simplified`, `interprets_articles`, `mentions_regulations`. | Not consumed by any component (reference only) |
+At build time, Quartz emits a JSON file consumed by client-side search and graph.
 
----
+| Field | Type | Source | Used for |
+|-------|------|--------|----------|
+| key (slug) | string | file path → slug | Page identity, graph node ID |
+| `title` | string | `frontmatter.title` | Search index, graph node label |
+| `links` | string[] | Wikilinks extracted from body | Graph edges, backlink resolution |
+| `tags` | string[] | `frontmatter.tags` | Search tag filter, graph tag nodes |
+| `content` | string | Full page text (HTML stripped) | Full-text search |
 
-## Table B: Article Frontmatter Fields
+**Note:** `date` and `description` are computed during build but deliberately excluded from the JSON to reduce file size. They are only used for sitemap.xml and RSS feed generation.
 
-Each row is a field found in `content/Articles/Article N.md` files.
+### Search configuration
 
-| Field | Type | Required | Origin | Processing | Used By |
-|-------|------|----------|--------|-----------|---------|
-| `title` | string | Yes | Manual authoring | Format: `Article N` (e.g. `Article 17`). | `ArticleTitle.tsx`, breadcrumbs, search index, graph nodes |
-| `subtitle` | string | Yes | Manual authoring | Human-readable article name (e.g. `Right to erasure ('right to be forgotten')`). | `Backlinks.tsx` (shown as subtitle under backlink) |
+- Engine: FlexSearch (client-side)
+- Tokenization: "forward" (prefix matching)
+- Indexed fields: `title`, `content`, `tags`
+- Max results: 8
 
-**Note:** Article pages have minimal frontmatter. Their body content contains the GDPR article text. Cross-references to cases are computed dynamically by `ArticleCases.tsx` which filters `allFiles` by `ruling-articles` matching the article number.
+### Graph configuration
 
----
-
-## Table C: General/Index Page Frontmatter Fields
-
-Fields found on `content/index.md`, browse pages, and generated index files.
-
-| Field | Type | Required | Origin | Processing | Used By |
-|-------|------|----------|--------|-----------|---------|
-| `title` | string | Yes | Manual | E.g. `Welcome!`, `Browse by topic` | All title-consuming components |
-| `subtitle` | string | No | Manual | Descriptive subtitle | Display only |
-| `tags` | string[] | No | Manual | E.g. `["hidden"]` to exclude from listings | `TagList.tsx`, `TagContent.tsx`, `RecentNotes.tsx` (filter), search index |
-| `cssclasses` | string[] | No | Manual | E.g. `["no-date", "no-title"]` | `Content.tsx` (applied as CSS classes on `<article>`) |
+- Rendering: D3.js force simulation
+- Nodes: Every page in contentIndex
+- Edges: Directed links from `links[]` array
+- Neighborhood: BFS from current page, configurable depth
+- Optional tag nodes: Creates synthetic `#tag` nodes
 
 ---
 
-## Table D: Quartz-Internal VFile Data (QuartzPluginData)
+## 13. Suggested Database Schema
 
-These fields are attached to `vfile.data` during the Quartz transform pipeline. They do not exist in markdown files; they are computed at build time.
+Based on the above analysis, here is a normalized relational schema capturing all GDPRed data:
 
-**Source:** `quartz/plugins/vfile.ts` + module augmentations in each transformer.
+```sql
+-- Core entities
+CREATE TABLE cases (
+    id              SERIAL PRIMARY KEY,
+    case_number     VARCHAR(20) NOT NULL UNIQUE,  -- "C-492/23"
+    title           VARCHAR(100) NOT NULL,         -- Usually same as case_number
+    date            DATE,                          -- Judgment date
+    parties         TEXT,                          -- "Plaintiff v Defendant"
+    final_ruling    TEXT,                          -- Numbered ruling paragraphs
+    body_markdown   TEXT NOT NULL,                 -- Full ruling text
+    body_plain_text TEXT,                          -- Stripped text for search
+    celex_id        VARCHAR(20),                   -- "62023CJ0492"
+    gdpr_summary    TEXT,                          -- Optional enrichment
+    created_at      TIMESTAMP DEFAULT NOW(),
+    updated_at      TIMESTAMP DEFAULT NOW()
+);
 
-| Field | Type | Set By | Source File | Description | Consumed By |
-|-------|------|--------|-------------|-------------|-------------|
-| `slug` | `FullSlug` | Core VFile setup | `quartz/build.ts` | Canonical page slug (e.g. `Case-law/C-492-23`) | All components via `fileData.slug`, link resolution, graph, search |
-| `filePath` | `FilePath` | Core VFile setup | `quartz/build.ts` | Disk path (e.g. `content/Case law/C-492-23.md`) | `Head.tsx`, `Content.tsx`, dep graph |
-| `relativePath` | `FilePath` | Core VFile setup | `quartz/build.ts` | Path relative to content dir | Internal path utilities |
-| `frontmatter` | object | `FrontMatter` transformer | `quartz/plugins/transformers/frontmatter.ts` | Parsed YAML/TOML frontmatter (see Tables A-C). Always has `title: string`. | Nearly all components |
-| `aliases` | `FullSlug[]` | `FrontMatter` transformer | `quartz/plugins/transformers/frontmatter.ts` | Resolved alias slugs from `frontmatter.aliases`. Pushed into `allSlugs`. | `aliases.ts` emitter (redirect pages) |
-| `dates` | `{ created: Date, modified: Date, published: Date }` | `CreatedModifiedDate` transformer | `quartz/plugins/transformers/lastmod.ts` | Resolved dates from frontmatter, git history, or filesystem. Priority order configurable. | `ContentMeta.tsx`, `PageList.tsx`, `RecentNotes.tsx`, `FolderContent.tsx`, sitemap, RSS |
-| `links` | `SimpleSlug[]` | `CrawlLinks` transformer | `quartz/plugins/transformers/links.ts` | All outgoing internal links from this page. | `Backlinks.tsx` (reverse lookup), graph edges, `ContentIndex` (`links` field) |
-| `description` | string | `Description` transformer | `quartz/plugins/transformers/description.ts` | Auto-generated meta description (first N chars of content). | `Head.tsx` (OG meta), RSS feed description |
-| `text` | string | `Description` transformer | `quartz/plugins/transformers/description.ts` | Plain-text extraction of full page content (HTML stripped). | `ContentMeta.tsx` (reading time calc), `ContentIndex` (`content` field for search) |
-| `toc` | `TocEntry[]` | `TableOfContents` transformer | `quartz/plugins/transformers/toc.ts` | Array of `{ depth: number, text: string, slug: string }` heading entries. | `TableOfContents.tsx` (renders TOC sidebar) |
-| `collapseToc` | boolean | `TableOfContents` transformer | `quartz/plugins/transformers/toc.ts` | Whether TOC starts collapsed. | `TableOfContents.tsx` (initial collapse state) |
-| `htmlAst` | `HtmlRoot` | `ObsidianFlavoredMarkdown` transformer | `quartz/plugins/transformers/ofm.ts` | Full HTML AST clone for transclusion support. | `renderPage.tsx` (resolves `![[embed]]` transclusions) |
-| `blocks` | `Record<string, Element>` | `ObsidianFlavoredMarkdown` transformer | `quartz/plugins/transformers/ofm.ts` | Map of block IDs to HTML elements (for `^blockref` transclusions). | `renderPage.tsx` (block-level transclusions) |
-| `hasMermaidDiagram` | boolean | `ObsidianFlavoredMarkdown` transformer | `quartz/plugins/transformers/ofm.ts` | Whether page contains mermaid diagrams. | `renderPage.tsx` (conditionally loads mermaid.js) |
+CREATE TABLE articles (
+    id              SERIAL PRIMARY KEY,
+    article_number  INTEGER NOT NULL UNIQUE CHECK (article_number BETWEEN 1 AND 99),
+    title           VARCHAR(50) NOT NULL,          -- "Article 17"
+    subtitle        VARCHAR(200),                  -- "Right to erasure"
+    body_markdown   TEXT NOT NULL,                 -- Regulatory text
+    body_plain_text TEXT                           -- Stripped text for search
+);
 
-### TocEntry Structure
+-- Many-to-many: Cases <-> Articles (the core relationship)
+CREATE TABLE case_ruling_articles (
+    case_id     INTEGER REFERENCES cases(id) ON DELETE CASCADE,
+    article_id  INTEGER REFERENCES articles(id) ON DELETE CASCADE,
+    PRIMARY KEY (case_id, article_id)
+);
 
-```
-{
-  depth: number    // Heading level (1-6)
-  text: string     // Heading text content
-  slug: string     // Anchor slug for linking (e.g. "introduction")
-}
-```
+-- Free-text topics from court tagging
+CREATE TABLE topics (
+    id          SERIAL PRIMARY KEY,
+    topic_text  VARCHAR(500) NOT NULL UNIQUE
+);
 
----
+CREATE TABLE case_topics (
+    case_id     INTEGER REFERENCES cases(id) ON DELETE CASCADE,
+    topic_id    INTEGER REFERENCES topics(id) ON DELETE CASCADE,
+    sort_order  INTEGER,
+    PRIMARY KEY (case_id, topic_id)
+);
 
-## Table E: Global Configuration Fields
+-- Per-article interpretations (what case X says about article Y)
+CREATE TABLE per_article_interpretations (
+    id                  SERIAL PRIMARY KEY,
+    case_id             INTEGER REFERENCES cases(id) ON DELETE CASCADE,
+    article_reference   VARCHAR(50) NOT NULL,  -- "Article 2(c)" — may include sub-paragraph
+    interpretation_text TEXT NOT NULL,
+    sort_order          INTEGER
+);
 
-**Source:** `quartz/cfg.ts` -> `GlobalConfiguration` interface. Set in `quartz.config.ts`.
+-- Structured operative parts (from JSON enrichment)
+CREATE TABLE operative_parts (
+    id                  SERIAL PRIMARY KEY,
+    case_id             INTEGER REFERENCES cases(id) ON DELETE CASCADE,
+    part_number         INTEGER NOT NULL,
+    verbatim_text       TEXT NOT NULL,
+    simplified_text     TEXT,
+    interprets_articles INTEGER[],     -- Article numbers
+    mentions_regulations TEXT[]        -- Regulation names
+);
 
-| Field | Type | Default (GDPRed) | Description | Used By |
-|-------|------|-------------------|-------------|---------|
-| `pageTitle` | string | `"GDPRed"` | Site title displayed in header | `PageTitle.tsx`, RSS feed `<title>`, OG meta |
-| `pageTitleSuffix` | string? | _(none)_ | Appended to page titles in `<title>` tag | `Head.tsx` |
-| `enableSPA` | boolean | `true` | Single-page-app navigation (prevents full reloads) | Client-side router (`spa.inline.ts`) |
-| `enablePopovers` | boolean | `true` | Wikipedia-style link previews on hover | `popover.inline.ts` |
-| `analytics` | Analytics | _(null or configured)_ | Analytics provider config | `Head.tsx` (injects tracking script) |
-| `ignorePatterns` | string[] | `["private", ...]` | Glob patterns for files to exclude from build | `quartz/build.ts` (file discovery) |
-| `defaultDateType` | `"created" \| "modified" \| "published"` | `"created"` | Which date to display by default | `getDate()` utility, `ContentMeta.tsx` |
-| `baseUrl` | string? | `"gdpred.milos.no"` | Base URL for sitemap, RSS, CNAME | Sitemap URLs, RSS links, OG meta URLs, CNAME file |
-| `generateSocialImages` | boolean \| SocialImageOptions | _(configured)_ | Auto-generate OG images | `Head.tsx` (Satori-based image generation) |
-| `theme` | Theme | _(see below)_ | Typography, colors, font config | `Head.tsx` (font loading), all CSS variables |
-| `locale` | ValidLocale | `"en-US"` | BCP 47 locale for dates and UI strings | All components using `i18n()`, date formatting |
+-- Curated topic taxonomy (the 14-category browsing structure)
+CREATE TABLE taxonomy_categories (
+    id          SERIAL PRIMARY KEY,
+    name        VARCHAR(200) NOT NULL,
+    sort_order  INTEGER NOT NULL
+);
 
-### Theme Sub-Structure
+CREATE TABLE taxonomy_subtopics (
+    id          SERIAL PRIMARY KEY,
+    category_id INTEGER REFERENCES taxonomy_categories(id) ON DELETE CASCADE,
+    name        VARCHAR(200) NOT NULL,
+    sort_order  INTEGER NOT NULL
+);
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `theme.typography.header` | string | Header font family (e.g. `IBM Plex Sans`) |
-| `theme.typography.body` | string | Body font family |
-| `theme.typography.code` | string | Code font family |
-| `theme.cdnCaching` | boolean | Whether to use CDN for fonts |
-| `theme.fontOrigin` | `"googleFonts" \| "local"` | Font loading source |
-| `theme.colors.lightMode` | ColorScheme | 9 color tokens for light theme |
-| `theme.colors.darkMode` | ColorScheme | 9 color tokens for dark theme |
+CREATE TABLE taxonomy_case_refs (
+    subtopic_id INTEGER REFERENCES taxonomy_subtopics(id) ON DELETE CASCADE,
+    case_id     INTEGER REFERENCES cases(id) ON DELETE CASCADE,
+    PRIMARY KEY (subtopic_id, case_id)
+);
 
-### ColorScheme Tokens
+-- General pages (non-case, non-article content)
+CREATE TABLE pages (
+    id              SERIAL PRIMARY KEY,
+    slug            VARCHAR(200) NOT NULL UNIQUE,
+    title           VARCHAR(200) NOT NULL,
+    subtitle        VARCHAR(200),
+    body_markdown   TEXT,
+    body_plain_text TEXT,
+    page_type       VARCHAR(20) NOT NULL CHECK (page_type IN ('case', 'article', 'page')),
+    -- FK to specific type (nullable)
+    case_id         INTEGER REFERENCES cases(id),
+    article_id      INTEGER REFERENCES articles(id),
+    -- Presentation
+    css_classes     TEXT[],
+    is_draft        BOOLEAN DEFAULT FALSE,
+    created_at      TIMESTAMP,
+    modified_at     TIMESTAMP
+);
 
-Each mode (light/dark) defines: `light`, `lightgray`, `gray`, `darkgray`, `dark`, `secondary`, `tertiary`, `highlight`, `textHighlight`.
+-- Tags (very lightly used: only ~5 pages have tags)
+CREATE TABLE tags (
+    id      SERIAL PRIMARY KEY,
+    slug    VARCHAR(100) NOT NULL UNIQUE,
+    name    VARCHAR(100) NOT NULL
+);
 
----
+CREATE TABLE page_tags (
+    page_id INTEGER REFERENCES pages(id) ON DELETE CASCADE,
+    tag_id  INTEGER REFERENCES tags(id) ON DELETE CASCADE,
+    PRIMARY KEY (page_id, tag_id)
+);
 
-## Table F: Content Index (Search/Graph Payload)
+-- Directed links between pages (for backlinks + graph)
+CREATE TABLE page_links (
+    source_page_id  INTEGER REFERENCES pages(id) ON DELETE CASCADE,
+    target_page_id  INTEGER REFERENCES pages(id) ON DELETE CASCADE,
+    PRIMARY KEY (source_page_id, target_page_id)
+);
 
-**Source:** `quartz/plugins/emitters/contentIndex.ts`
-**Output:** `static/contentIndex.json`
+-- Aliases/redirects
+CREATE TABLE case_aliases (
+    id          SERIAL PRIMARY KEY,
+    case_id     INTEGER REFERENCES cases(id) ON DELETE CASCADE,
+    alias_slug  VARCHAR(200) NOT NULL UNIQUE
+);
 
-This is the JSON blob loaded client-side for search and graph visualization.
+-- Full-text search (PostgreSQL-specific)
+ALTER TABLE pages ADD COLUMN search_vector tsvector;
+CREATE INDEX pages_search_idx ON pages USING gin(search_vector);
 
-| Field | Type | Source | Used By Search | Used By Graph | In JSON |
-|-------|------|--------|---------------|---------------|---------|
-| _key_ (slug) | `FullSlug` | `vfile.data.slug` | Result linking | Node ID | Yes |
-| `title` | string | `frontmatter.title` | Indexed (tokenize: forward) | Node label | Yes |
-| `links` | `SimpleSlug[]` | `vfile.data.links` | Not indexed | Edge targets | Yes |
-| `tags` | string[] | `frontmatter.tags` | Indexed + tag filter | Tag nodes (if enabled) | Yes |
-| `content` | string | `vfile.data.text` | Indexed (tokenize: forward) | Not used | Yes |
-| `richContent` | string? | HAST-to-HTML of full page | Not used | Not used | Only if `rssFullHtml` |
-| `date` | Date? | `getDate()` from dates | Not used | Not used | **No** (stripped) |
-| `description` | string? | `vfile.data.description` | Not used | Not used | **No** (stripped) |
-
-**Note:** `date` and `description` are stripped from `contentIndex.json` to reduce file size. They are only used for sitemap.xml and RSS (index.xml).
-
-### FlexSearch Index Configuration (client-side)
-
-```
-Document index fields:
-  - title     (tokenize: "forward")
-  - content   (tokenize: "forward")
-  - tags      (tokenize: "forward")
-Tag field: "tags" (used for #tag filtering)
-Max results: 8 (basic search), 5 (tag search)
-```
-
-### Graph Data Usage (client-side)
-
-```
-Nodes: Each slug in contentIndex -> node
-  - Label: ContentDetails.title
-  - Color: secondary (current), tertiary (visited), gray (unvisited)
-Edges: ContentDetails.links -> directed edges to other nodes
-Tag nodes (optional): ContentDetails.tags -> synthetic nodes prefixed with #
-Neighborhood: BFS from current page to configurable depth
-Rendering: D3.js force simulation + Pixi.js GPU rendering
-```
-
----
-
-## Table G: Pipeline Script I/O
-
-Complete input/output mapping for every processing script.
-
-| Script | Input | Processing | Output |
-|--------|-------|-----------|--------|
-| `sparql-discover.js` | SPARQL endpoint + existing `content/Case law/` filenames | Queries Publications Office, filters/deduplicates, compares against existing | `scripts/pipeline/new-cases.json` |
-| `fetch-html.js` | `new-cases.json` (caseCelex IDs) | HTTP GET from EUR-Lex with rate limiting | `scripts/pipeline/downloaded/{celex}.html` |
-| `generate-frontmatter.js` | Case data object + raw HTML | Cheerio parsing of ruling, topics, articles; merge SPARQL + HTML data | YAML frontmatter object (returned to caller) |
-| `html-to-md.cjs` | Raw EUR-Lex HTML | Turndown HTML-to-Markdown, paragraph consolidation, numbering cleanup | Markdown body string (returned to caller) |
-| `assemble-case.js` | Case data + HTML file path | Calls generate-frontmatter + html-to-md, combines | `content/Case law/{case-number}.md` |
-| `run-pipeline.js` | CLI args (`--dry-run`, `--force-celex`, `--limit`) | Orchestrates discover -> download -> assemble -> post-process | All outputs above + console summary |
-| `extract_case_articles.cjs` | All `content/Case law/*.md` | Parses frontmatter, extracts `[[Article N]]` refs, builds cross-ref maps | `cases_by_article.md`, `articles_by_case.md` (root) |
-| `extract_article_rulings.js` | `key-articles-by-case.md` + case law files | Extracts ruling paragraphs per article per case | `content/article-rulings.md` |
-| `process_article_refs.cjs` | All `content/**/*.md` | Finds `[[Article N]]` where N>99 (invalid), replaces with plain text | Modified .md files + `article_modifications.md` log + `backup_content/` |
-| `apply_json_frontmatter.js` | `case-metadata.json` + case law .md files | Maps JSON metadata to YAML, replaces frontmatter | Modified .md files (with `.bak_json_apply` backups) |
-| `check_frontmatter.js` | All `content/**/*.md` | Validates YAML syntax, checks for missing frontmatter | Console report (no file changes) |
-| `generate-timeline.js` | All `content/Case law/*.md` | Extracts date/title/parties/topics, groups by month, generates HTML | Inserts timeline HTML into `content/index.md` |
-| `generate-case-grid.js` | All `content/Case law/*.md` | Extracts date/title/parties/topics, generates card grid HTML | `content/case-law-grid.md` |
-
----
-
-## Table H: Component Data Consumption
-
-What data each UI component reads and how it uses it.
-
-| Component | fileData Fields | allFiles Fields | cfg Fields | Renders |
-|-----------|----------------|-----------------|-----------|---------|
-| `ArticleTitle.tsx` | `frontmatter.title` | -- | -- | `<h1>` with page title |
-| `Parties.tsx` | `frontmatter.parties` | -- | -- | Styled `<h2>` with italic parties text |
-| `NowReading.tsx` | `frontmatter["ruling-articles"]`, `slug` | -- | -- | Article chips with links to `/Articles/Article-N` |
-| `ArticleCases.tsx` | `slug` (extracts article number) | `frontmatter["ruling-articles"]`, `slug`, `frontmatter.title`, `frontmatter.date`, `frontmatter.parties` | `locale` | Collapsible list of cases referencing this article |
-| `ContentMeta.tsx` | `text`, `dates`, `slug` | -- | `locale` | Date display + reading time (e.g. "5 min read") |
-| `TagList.tsx` | `frontmatter.tags`, `slug` | -- | -- | Tag links to `/tags/{slug}` |
-| `Head.tsx` | `filePath`, `frontmatter.title`, `description`, `frontmatter.socialImage`, `slug` | -- | `generateSocialImages`, `locale`, `pageTitleSuffix`, `baseUrl`, `theme`, `pageTitle` | `<head>` with meta tags, OG/Twitter cards, fonts, CSS/JS |
-| `PageTitle.tsx` | `slug` | -- | `pageTitle`, `locale` | Site title link to homepage |
-| `Backlinks.tsx` | `slug` | `links` (reverse lookup), `slug`, `frontmatter.title`, `frontmatter.parties`, `frontmatter.subtitle` | `locale` | List of pages linking to current page |
-| `TableOfContents.tsx` | `toc`, `collapseToc` | -- | `locale` | Collapsible TOC with depth-based indentation |
-| `Breadcrumbs.tsx` | `slug`, `frontmatter.title` | `slug`, `frontmatter.title` (index files) | -- | Navigation breadcrumb trail |
-| `Explorer.tsx` | _(nested)_ | `slug` (builds file tree) | `locale` | Sidebar file explorer navigation |
-| `Graph.tsx` | -- | -- | `locale` | D3/Pixi graph (data loaded client-side from contentIndex.json) |
-| `Search.tsx` | -- | -- | `locale` | Search UI (data loaded client-side from contentIndex.json) |
-| `Content.tsx` | `filePath`, `frontmatter.cssclasses` | -- | -- | `<article>` with rendered markdown content |
-| `FolderContent.tsx` | `slug`, `frontmatter.cssclasses`, `description` | `slug`, `dates`, `frontmatter.title`, `frontmatter.tags` | `locale` | Folder page with child page listings |
-| `TagContent.tsx` | `slug`, `frontmatter.cssclasses`, `description` | `frontmatter.tags` (filter) | `locale` | Tag index or single-tag page with page listings |
-| `TopicExplorer.tsx` | `slug` | `slug`, `frontmatter["case-number"]`, `frontmatter.title` | -- | Hierarchical GDPR topic browser with case links |
-| `renderPage.tsx` | `frontmatter.lang`, `slug`, `hasMermaidDiagram` | `slug`, `frontmatter.title`, `htmlAst`, `blocks` | `locale` | Full HTML page assembly with transclusion resolution |
-| `RecentNotes.tsx` | `slug` | `frontmatter.title`, `frontmatter.tags`, `dates` | `locale` | Recent pages list sorted by date |
-| `PageList.tsx` | `slug` | `frontmatter.title`, `frontmatter.tags`, `dates` | `locale` | Generic sorted/limited page listing |
-| `Body.tsx` | -- | -- | -- | Wrapper `<div id="quartz-body">` |
-
----
-
-## Table I: Frontmatter Alias Resolution
-
-The `FrontMatter` transformer coalesces multiple possible field names into canonical fields.
-
-**Source:** `quartz/plugins/transformers/frontmatter.ts:84-110`
-
-| Canonical Field | Accepted Aliases (checked in order) | Coercion |
-|----------------|-------------------------------------|----------|
-| `tags` | `tags`, `tag` | Coerced to string[], split on `,` if string, deduplicated via `slugTag()` |
-| `aliases` | `aliases`, `alias` | Coerced to string[], resolved to `FullSlug[]` relative to file directory |
-| `cssclasses` | `cssclasses`, `cssclass` | Coerced to string[] |
-| `socialImage` | `socialImage`, `image`, `cover` | Kept as string |
-| `created` | `created`, `date` | Kept as string (later parsed to Date by `lastmod.ts`) |
-| `modified` | `modified`, `lastmod`, `updated`, `last-modified` | Kept as string (later parsed to Date by `lastmod.ts`) |
-| `published` | `published`, `publishDate`, `date` | Kept as string (later parsed to Date by `lastmod.ts`) |
-
----
-
-## Table J: Output Artifacts
-
-All files generated by the Quartz build.
-
-| Artifact | Generator | Format | Contains |
-|----------|-----------|--------|----------|
-| `public/{slug}/index.html` | Page emitters (`ContentPage`, `FolderPage`, `TagPage`) | HTML | Full rendered page with all component output |
-| `public/static/contentIndex.json` | `ContentIndex` emitter | JSON | `Map<slug, {title, links, tags, content}>` |
-| `public/sitemap.xml` | `ContentIndex` emitter | XML | All slugs with `<lastmod>` dates |
-| `public/index.xml` | `ContentIndex` emitter | XML (RSS) | Recent pages with title, link, description, pubDate |
-| `public/{alias}/index.html` | `Aliases` emitter | HTML | Meta-refresh redirect + canonical link |
-| `public/static/*` | `Assets` emitter | Various | Static files (CSS, JS, fonts, images) |
-| `public/CNAME` | `CNAME` emitter | Text | `gdpred.milos.no` |
-| Tag index pages | `TagPage` emitter | HTML | Tag listing or per-tag page list |
-| Folder index pages | `FolderPage` emitter | HTML | Folder contents with child page listings |
-
----
-
-## Data Flow Diagram
-
-```
-                    EXTERNAL SOURCES
-                    ================
-    ┌──────────────────┐     ┌──────────────────┐     ┌──────────────┐
-    │ SPARQL Endpoint   │     │  EUR-Lex HTML     │     │ case-metadata│
-    │ (Publications     │     │  (Court rulings)  │     │ .json        │
-    │  Office EU)       │     │                   │     │ (optional)   │
-    └────────┬─────────┘     └────────┬──────────┘     └──────┬───────┘
-             │                        │                        │
-    ┌────────▼─────────┐     ┌────────▼──────────┐    ┌───────▼────────┐
-    │sparql-discover.js│     │  fetch-html.js     │    │apply_json_     │
-    │  Discovers new   │     │  Downloads HTML    │    │frontmatter.js  │
-    │  cases           │     │  from EUR-Lex      │    │  Enriches FM   │
-    └────────┬─────────┘     └────────┬──────────┘    └───────┬────────┘
-             │                        │                        │
-             └──────────┬─────────────┘                        │
-                        │                                      │
-               ┌────────▼──────────┐                           │
-               │  assemble-case.js │                           │
-               │  ┌──────────────┐ │                           │
-               │  │generate-     │ │                           │
-               │  │frontmatter.js│ │                           │
-               │  └──────────────┘ │                           │
-               │  ┌──────────────┐ │                           │
-               │  │html-to-md.cjs│ │                           │
-               │  └──────────────┘ │                           │
-               └────────┬──────────┘                           │
-                        │                                      │
-                        ▼                                      ▼
-    ┌──────────────────────────────────────────────────────────────────┐
-    │                  content/Case law/*.md                           │
-    │  ┌─────────────────────────────────────────────────────────┐    │
-    │  │ YAML Frontmatter:                                       │    │
-    │  │   title, date, case-number, parties, topics,            │    │
-    │  │   final-ruling, ruling-articles, per-article,           │    │
-    │  │   [celex-id, gdpr-summary, operative_parts_structured]  │    │
-    │  ├─────────────────────────────────────────────────────────┤    │
-    │  │ Markdown Body:                                          │    │
-    │  │   Full court ruling text converted from HTML            │    │
-    │  └─────────────────────────────────────────────────────────┘    │
-    └────────────────────────────┬─────────────────────────────────────┘
-                                 │
-          POST-PROCESSING        │
-          ===============        │
-    ┌────────────────────────────┼────────────────────────────────┐
-    │                            ▼                                │
-    │  ┌──────────────────┐  ┌──────────────────┐  ┌──────────┐  │
-    │  │extract_case_     │  │extract_article_  │  │process_  │  │
-    │  │articles.cjs      │  │rulings.js        │  │article_  │  │
-    │  │→cases_by_article │  │→article-rulings  │  │refs.cjs  │  │
-    │  │→articles_by_case │  │  .md             │  │→fix >99  │  │
-    │  └──────────────────┘  └──────────────────┘  └──────────┘  │
-    │                                                             │
-    │  ┌──────────────────┐  ┌──────────────────┐                │
-    │  │generate-         │  │generate-case-    │                │
-    │  │timeline.js       │  │grid.js           │                │
-    │  │→index.md timeline│  │→case-law-grid.md │                │
-    │  └──────────────────┘  └──────────────────┘                │
-    └─────────────────────────────┬───────────────────────────────┘
-                                  │
-                                  ▼
-    ┌──────────────────────────────────────────────────────────────┐
-    │                    QUARTZ BUILD PIPELINE                     │
-    │                                                              │
-    │  PARSE ──► TRANSFORM ──► FILTER ──► EMIT                    │
-    │                                                              │
-    │  Parse:                                                      │
-    │    Markdown → AST (mdast) + VFile                            │
-    │                                                              │
-    │  Transform (Markdown stage):                                 │
-    │    FrontMatter    → vfile.data.frontmatter, .aliases         │
-    │    GFM            → Tables, strikethrough, autolinks         │
-    │    OFM            → Wikilinks, embeds, tags, .blocks,        │
-    │                     .htmlAst, .hasMermaidDiagram              │
-    │    Citations      → Bibliography references                  │
-    │    Linebreaks     → Hard line breaks                         │
-    │                                                              │
-    │  [Markdown AST → HTML AST conversion]                        │
-    │                                                              │
-    │  Transform (HTML stage):                                     │
-    │    CrawlLinks     → vfile.data.links (SimpleSlug[])          │
-    │    Description    → vfile.data.description, .text            │
-    │    TableOfContents→ vfile.data.toc, .collapseToc             │
-    │    CreatedModified→ vfile.data.dates                         │
-    │    SyntaxHighlight→ Code block theming                       │
-    │    Latex          → Math rendering                           │
-    │                                                              │
-    │  Filter:                                                     │
-    │    RemoveDrafts   → Excludes draft:true / publish:false      │
-    │                                                              │
-    │  Emit:                                                       │
-    │    ContentPage    → public/{slug}/index.html                 │
-    │    FolderPage     → public/{folder}/index.html               │
-    │    TagPage        → public/tags/{tag}/index.html             │
-    │    ContentIndex   → static/contentIndex.json + sitemap + RSS │
-    │    Aliases        → public/{alias}/index.html (redirects)    │
-    │    Assets         → public/static/* (CSS, JS, fonts)         │
-    │    CNAME          → public/CNAME                             │
-    └──────────────────────────────────────────────────────────────┘
+-- Update search vector trigger
+CREATE OR REPLACE FUNCTION update_search_vector() RETURNS trigger AS $$
+BEGIN
+    NEW.search_vector := to_tsvector('english',
+        coalesce(NEW.title, '') || ' ' ||
+        coalesce(NEW.body_plain_text, '')
+    );
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
 ```
 
----
+### Key design decisions
 
-## Cross-Reference Systems
+1. **`pages` as a unified table** with `page_type` discriminator — allows link graph to work uniformly across all content types while `case_id`/`article_id` FKs provide type-specific access.
 
-### 1. Case → Article Links
+2. **Topics vs. Taxonomy** are deliberately separate — `topics` is the raw court tagging (messy, uncontrolled), `taxonomy_*` is the curated browse structure (14 categories, ~60 subtopics).
 
-**Direction:** Case law pages reference GDPR articles.
+3. **`per_article_interpretations`** uses `article_reference` as a string (not FK) because it includes sub-paragraphs like `Article 2(c)` that don't map 1:1 to the `articles` table.
 
-| Layer | Mechanism | Data Field |
-|-------|-----------|-----------|
-| Frontmatter | `ruling-articles: ["Article 17", "Article 21"]` | Explicit list |
-| Body text | `[[Article 17]]` wikilinks | Parsed by OFM transformer into `links` |
-| Component | `NowReading.tsx` reads `ruling-articles`, generates chip links | Direct frontmatter read |
-
-### 2. Article → Case Links (reverse)
-
-**Direction:** Article pages show which cases reference them.
-
-| Layer | Mechanism | Data Field |
-|-------|-----------|-----------|
-| Component | `ArticleCases.tsx` extracts article number from slug, filters `allFiles` where `ruling-articles` includes this article | Computed at render time from `allFiles` |
-| Backlinks | `Backlinks.tsx` finds all files whose `links` array contains current article's slug | Computed from `vfile.data.links` |
-
-### 3. Inter-Case Links
-
-**Direction:** Cases may link to other cases via wikilinks in body text.
-
-| Layer | Mechanism | Data Field |
-|-------|-----------|-----------|
-| Body text | `[[C-492-23]]` wikilinks | Parsed into `links` by OFM + CrawlLinks |
-| Graph | Edges drawn from `ContentDetails.links` in contentIndex.json | Client-side D3 rendering |
-| Backlinks | Reverse lookup of `links` array | `Backlinks.tsx` |
-
-### 4. Generated Cross-Reference Indexes
-
-| File | Generator | Structure |
-|------|-----------|-----------|
-| `cases_by_article.md` | `extract_case_articles.cjs` | Per case: list of referenced articles |
-| `articles_by_case.md` | `extract_case_articles.cjs` | Per article: list of referencing cases |
-| `article-rulings.md` | `extract_article_rulings.js` | Per article: relevant ruling text from each case |
-| `key-articles-by-case.md` | _(manual/generated)_ | Key articles grouped by case |
-
-### 5. Search System
-
-| Indexed Field | Source | Search Type |
-|--------------|--------|-------------|
-| `title` | `frontmatter.title` | Forward tokenization, prefix matching |
-| `content` | `vfile.data.text` (plain text) | Forward tokenization, prefix matching |
-| `tags` | `frontmatter.tags` | Tag filtering with `#` prefix, forward tokenization |
-
-### 6. Graph Visualization
-
-| Node Type | Source | Visual |
-|-----------|--------|--------|
-| Page node | Each slug in contentIndex | Circle, color varies by state |
-| Tag node (optional) | `ContentDetails.tags` | Circle with border, "light" color |
-| Edge (link) | `ContentDetails.links[i]` → target slug | Directed line |
-| Edge (tag) | Page slug → `tags/{tagname}` | Directed line |
+4. **`page_links`** replaces the wikilink/backlink system — at ingest time, parse `[[wikilinks]]` from body text and insert directional edges.
 
 ---
 
-## Appendix: Complete Transformer Pipeline Order
+## Appendix: Quartz Build-Time Computed Fields
 
-As configured in `quartz.config.ts`:
+These fields don't exist in the source data but are computed during the Quartz build. A database backend would compute them differently.
+
+| Field | Currently computed by | What to do instead |
+|-------|----------------------|--------------------|
+| `slug` | File path → slug conversion | Use `pages.slug` column |
+| `links[]` | OFM + CrawlLinks transformers parse wikilinks from body | Parse at ingest time, store in `page_links` table |
+| `description` | First N chars of plain text | Compute at ingest or use `LEFT(body_plain_text, 200)` |
+| `text` (plain) | HTML stripping of rendered content | Strip markdown at ingest, store as `body_plain_text` |
+| `toc` | Heading extraction from AST | Parse headings from markdown at render time or ingest |
+| `dates.created/modified` | Git history, filesystem, frontmatter | Store as columns, update via triggers |
+| `reading_time` | Word count of `text` field | `length(body_plain_text) / 5 / 200` (words/wpm) |
+
+---
+
+## Appendix: Data Flow Diagram
 
 ```
-1. FrontMatter        → Parse YAML, resolve aliases, coerce types
-2. CreatedModifiedDate → Resolve dates from frontmatter/git/filesystem
-3. Latex               → Render math expressions
-4. SyntaxHighlighting  → Highlight code blocks
-5. ObsidianFlavoredMarkdown → Wikilinks, embeds, tags, callouts, blocks
-6. GitHubFlavoredMarkdown   → Tables, strikethrough, autolinks
-7. CrawlLinks         → Resolve links, classify internal/external, populate links[]
-8. Description         → Extract plain text and meta description
-9. TableOfContents     → Generate heading tree
+    EXTERNAL SOURCES                    DATABASE
+    ================                    ========
+
+    SPARQL ──────────┐
+    (discover cases) │
+                     ├──► Ingest ──► cases table
+    EUR-Lex HTML ────┤    Script      case_ruling_articles
+    (ruling text)    │                case_topics
+                     │                per_article_interpretations
+    JSON metadata ───┘                operative_parts
+    (enrichment)                      page_links (parsed from body)
+                                      pages (unified, type='case')
+
+    Manual content ──────► Import ──► articles table
+    (Article .md files)    Script     pages (type='article')
+
+    Browse by topic.md ──► Parse ───► taxonomy_categories
+    (curated taxonomy)     Script     taxonomy_subtopics
+                                      taxonomy_case_refs
+
+                                         │
+                                         ▼
+                                    ┌─────────┐
+                                    │   API    │
+                                    │  Layer   │
+                                    └────┬────┘
+                                         │
+                     ┌───────────────────┼──────────────────────┐
+                     │                   │                      │
+                     ▼                   ▼                      ▼
+              Case pages          Article pages          Browse/Search
+              - parties           - subtitle             - taxonomy tree
+              - ruling chips      - case list            - full-text search
+              - topics            - backlinks            - link graph
+              - body                                     - timeline
+              - backlinks                                - case grid
 ```
-
-Each transformer can operate at three stages:
-- `textTransform`: Raw text manipulation before parsing
-- `markdownPlugins`: Remark plugins operating on mdast
-- `htmlPlugins`: Rehype plugins operating on hast
-
----
-
-## Appendix: Slug Type System
-
-Quartz uses branded string types for type safety:
-
-| Type | Pattern | Example | Usage |
-|------|---------|---------|-------|
-| `FilePath` | Absolute, with extension | `content/Case law/C-492-23.md` | Disk I/O, dep graph |
-| `FullSlug` | No leading/trailing slash, may have `index` | `Case-law/C-492-23` | Canonical page identity |
-| `SimpleSlug` | No `/index`, no extension | `Case-law/C-492-23` | Links, graph edges, backlinks |
-| `RelativeURL` | Can be relative | `../Articles/Article-17` | href attributes in HTML |

--- a/DATA-SCHEMA-MAP.md
+++ b/DATA-SCHEMA-MAP.md
@@ -1,0 +1,600 @@
+# GDPRed Data Schema Map
+
+> Complete mapping of every data field, its origin, processing, and usage.
+> Use this as the definitive reference for recreating the GDPRed pipeline without Quartz.
+
+---
+
+## Table of Contents
+
+1. [Architecture Overview](#1-architecture-overview)
+2. [External Data Sources](#2-external-data-sources)
+3. [Content Entities](#3-content-entities)
+4. [Table A: Case Law Frontmatter Fields](#table-a-case-law-frontmatter-fields)
+5. [Table B: Article Frontmatter Fields](#table-b-article-frontmatter-fields)
+6. [Table C: General/Index Page Frontmatter Fields](#table-c-generalindex-page-frontmatter-fields)
+7. [Table D: Quartz-Internal VFile Data (QuartzPluginData)](#table-d-quartz-internal-vfile-data-quartzplugindata)
+8. [Table E: Global Configuration Fields](#table-e-global-configuration-fields)
+9. [Table F: Content Index (Search/Graph Payload)](#table-f-content-index-searchgraph-payload)
+10. [Table G: Pipeline Script I/O](#table-g-pipeline-script-io)
+11. [Table H: Component Data Consumption](#table-h-component-data-consumption)
+12. [Table I: Frontmatter Alias Resolution](#table-i-frontmatter-alias-resolution)
+13. [Table J: Output Artifacts](#table-j-output-artifacts)
+14. [Data Flow Diagram](#data-flow-diagram)
+15. [Cross-Reference Systems](#cross-reference-systems)
+
+---
+
+## 1. Architecture Overview
+
+GDPRed is a GDPR case-law knowledge base. Data flows through four phases:
+
+```
+Phase 1: DISCOVERY     SPARQL endpoint -> new-cases.json
+Phase 2: DOWNLOAD      EUR-Lex HTML -> downloaded/*.html
+Phase 3: ASSEMBLY      HTML -> Markdown + YAML frontmatter -> content/Case law/*.md
+Phase 4: BUILD         Quartz pipeline: Parse -> Transform -> Filter -> Emit -> Static site
+```
+
+### Key Source Files
+
+| Concern | File(s) |
+|---------|---------|
+| Pipeline orchestrator | `scripts/pipeline/run-pipeline.js` |
+| Case discovery | `scripts/pipeline/sparql-discover.js` |
+| HTML download | `scripts/pipeline/fetch-html.js` |
+| Case assembly | `scripts/pipeline/assemble-case.js` |
+| Frontmatter generation | `scripts/pipeline/generate-frontmatter.js` |
+| HTML-to-Markdown | `scripts/html-to-md.cjs` |
+| VFile data types | `quartz/plugins/vfile.ts` |
+| Frontmatter parser | `quartz/plugins/transformers/frontmatter.ts` |
+| Link processing | `quartz/plugins/transformers/links.ts` |
+| Date processing | `quartz/plugins/transformers/lastmod.ts` |
+| TOC generation | `quartz/plugins/transformers/toc.ts` |
+| OFM (wikilinks) | `quartz/plugins/transformers/ofm.ts` |
+| Description extraction | `quartz/plugins/transformers/description.ts` |
+| Content index emitter | `quartz/plugins/emitters/contentIndex.ts` |
+| Global config types | `quartz/cfg.ts` |
+| Plugin types | `quartz/plugins/types.ts` |
+| Component types | `quartz/components/types.ts` |
+| Build orchestration | `quartz/build.ts` |
+
+---
+
+## 2. External Data Sources
+
+### 2a. SPARQL Publications Office
+
+| Property | Value |
+|----------|-------|
+| **Endpoint** | `https://publications.europa.eu/webapi/rdf/sparql` |
+| **Target regulation** | Regulation (EU) 2016/679 (GDPR) |
+| **Script** | `scripts/pipeline/sparql-discover.js` |
+
+**Fields returned per case:**
+
+| SPARQL Field | Type | Description | Maps to Frontmatter |
+|-------------|------|-------------|---------------------|
+| `caseCelex` | string | CELEX identifier (e.g. `62023CJ0492`) | `celex-id` (via JSON apply) |
+| `caseNumber` | string | Court case number (e.g. `Case C-492/23`) | `case-number`, `title` |
+| `caseDate` | string | Judgment date (ISO) | `date` |
+| `caseParties` | string | Parties involved | `parties` |
+| `caseShortTitle` | string | Short case title | _(used in pipeline logs)_ |
+| `caseTitle` | string | Full case title | _(used in pipeline logs)_ |
+| `modifiedLocations` | string | Article references (e.g. `A04P4, A05P2`) | `ruling-articles` (parsed) |
+
+**Filtering logic:**
+- Excludes non-CJ cases (pending cases marked "CN")
+- Excludes joined cases (flagged for manual review)
+- Deduplicates by CELEX ID
+- Only returns cases not already in `content/Case law/`
+
+### 2b. EUR-Lex HTML Documents
+
+| Property | Value |
+|----------|-------|
+| **URL pattern** | `https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:{caseCelex}` |
+| **Script** | `scripts/pipeline/fetch-html.js` |
+| **Rate limit** | 2 seconds between requests |
+| **Retry** | 3 attempts, exponential backoff (2s -> 4s -> 8s) |
+| **User-Agent** | `GDPRed-Pipeline/1.0` |
+| **Output** | `scripts/pipeline/downloaded/{caseCelex}.html` |
+
+**Data extracted from HTML** (by `generate-frontmatter.js`):
+
+| HTML Structure | CSS Class / Pattern | Extracted As |
+|---------------|-------------------|-------------|
+| Final ruling text | Between `C41DispositifIntroduction` and `C77Signatures` | `final-ruling` |
+| Topic indicators | `C71Indicateur` paragraph, split on `--` / `--` | `topics` array |
+| Article references | `Article N` patterns (N = 1-99) in ruling text | `ruling-articles` array |
+| Per-article rulings | Ruling paragraphs matched to article numbers | `per-article` array |
+| Full document body | Entire HTML content | Markdown body (via Turndown) |
+
+### 2c. External JSON Metadata (optional enrichment)
+
+| Property | Value |
+|----------|-------|
+| **File** | `case-metadata.json` (local) |
+| **Script** | `scripts/apply_json_frontmatter.js` |
+
+**JSON fields per case:**
+
+| JSON Field | Type | Maps to Frontmatter |
+|-----------|------|---------------------|
+| `caseId` | string | `case-number` |
+| `celexId` | string | `celex-id` |
+| `date` | string | `date` |
+| `parties` | string | `parties` |
+| `summary` | string | `gdpr-summary` |
+| `interpretedArticleNumbers` | number[] | `ruling-articles` (formatted as `Article N`) |
+| `operativePartsCombined` | string | `final-ruling` |
+| `operativeParts` | object[] | `operative_parts_structured` |
+| `operativeParts[].number` | number | `operative_parts_structured[].number` |
+| `operativeParts[].verbatimText` | string | `operative_parts_structured[].verbatim` |
+| `operativeParts[].simplifiedText` | string | `operative_parts_structured[].simplified` |
+| `operativeParts[].interpretedArticles` | number[] | `operative_parts_structured[].interprets_articles` |
+| `operativeParts[].regulations` | string[] | `operative_parts_structured[].mentions_regulations` |
+
+---
+
+## 3. Content Entities
+
+The system has three distinct content entity types:
+
+| Entity | Location | Count | Description |
+|--------|----------|-------|-------------|
+| **Case Law** | `content/Case law/*.md` | ~99 | Individual CJEU case judgments |
+| **Articles** | `content/Articles/Article N.md` | 99 | GDPR articles (1-99) |
+| **Index/Browse Pages** | `content/*.md` | ~10 | Navigation, timelines, grids |
+
+---
+
+## Table A: Case Law Frontmatter Fields
+
+Each row is a field found in `content/Case law/*.md` files.
+
+| Field | Type | Required | Origin | Processing | Used By |
+|-------|------|----------|--------|-----------|---------|
+| `title` | string | Yes | SPARQL `caseNumber` stripped to short form (e.g. `C-492/23`) | If absent, defaults to filename stem. `generate-frontmatter.js` formats from SPARQL data. | `ArticleTitle.tsx`, `Breadcrumbs.tsx`, `PageList.tsx`, `RecentNotes.tsx`, `Backlinks.tsx`, search index, graph nodes, RSS feed |
+| `date` | string (ISO 8601) | Yes | SPARQL `caseDate` | Stored as ISO string. Quartz `lastmod.ts` coalesces `created`/`date` aliases into `dates.created`, `dates.published`. | `ContentMeta.tsx` (display), `ArticleCases.tsx` (sorting), `PageList.tsx`, `RecentNotes.tsx`, sitemap `<lastmod>`, RSS `<pubDate>` |
+| `case-number` | string | Yes | SPARQL `caseNumber`, formatted as `C-XXX/YY` | `generate-frontmatter.js` normalizes from SPARQL. `apply_json_frontmatter.js` can override from JSON. | `TopicExplorer.tsx` (categorization), case grid generation, timeline generation |
+| `parties` | string | Yes | SPARQL `caseParties` or HTML extraction | Stored as `Plaintiff v Defendant` format. | `Parties.tsx` (renders as styled h2), `Backlinks.tsx` (subtitle), `ArticleCases.tsx` (list item), timeline, case grid |
+| `topics` | string[] | Yes | EUR-Lex HTML `C71Indicateur` paragraph | `generate-frontmatter.js` splits on `--`/`--`, filters generic phrases, trims whitespace. | `TopicExplorer.tsx` (hierarchical categorization), timeline (display), case grid (display) |
+| `final-ruling` | string (multiline) | Yes | EUR-Lex HTML between `C41DispositifIntroduction` and `C77Signatures` | `generate-frontmatter.js` extracts and formats numbered points as `**1.**` prefix. YAML block scalar (`\|` or `\|-`). | Rendered in case page body. Used by `extract_article_rulings.js` to build per-article ruling index. |
+| `ruling-articles` | string[] | Yes | EUR-Lex HTML + SPARQL `modifiedLocations` | `generate-frontmatter.js` finds `Article N` patterns (1-99) in ruling text, merges with SPARQL article refs, deduplicates. Format: `Article N` with `[[` wikilink brackets. | `NowReading.tsx` (article chip links), `ArticleCases.tsx` (cross-reference filter), `extract_case_articles.cjs` (index generation) |
+| `per-article` | string[] | No | EUR-Lex HTML ruling text | `generate-frontmatter.js` maps ruling paragraphs to specific articles. Format: `Article N \| ruling text...` | Rendered in case page body for per-article breakdown |
+| `aliases` | string[] | No | Manual or auto-generated | Quartz `frontmatter.ts` coalesces `aliases`/`alias`, converts to `FullSlug[]`, pushes to `allSlugs`. | `aliases.ts` emitter creates HTML redirect pages, `allSlugs` for link resolution |
+| `celex-id` | string | No | `apply_json_frontmatter.js` from JSON `celexId` | Direct mapping from external JSON metadata. | Not consumed by any component (reference only) |
+| `gdpr-summary` | string | No | `apply_json_frontmatter.js` from JSON `summary` | Direct mapping from external JSON metadata. | Not consumed by any component (reference only) |
+| `operative_parts_structured` | object[] | No | `apply_json_frontmatter.js` from JSON `operativeParts` | Structured array with `number`, `verbatim`, `simplified`, `interprets_articles`, `mentions_regulations`. | Not consumed by any component (reference only) |
+
+---
+
+## Table B: Article Frontmatter Fields
+
+Each row is a field found in `content/Articles/Article N.md` files.
+
+| Field | Type | Required | Origin | Processing | Used By |
+|-------|------|----------|--------|-----------|---------|
+| `title` | string | Yes | Manual authoring | Format: `Article N` (e.g. `Article 17`). | `ArticleTitle.tsx`, breadcrumbs, search index, graph nodes |
+| `subtitle` | string | Yes | Manual authoring | Human-readable article name (e.g. `Right to erasure ('right to be forgotten')`). | `Backlinks.tsx` (shown as subtitle under backlink) |
+
+**Note:** Article pages have minimal frontmatter. Their body content contains the GDPR article text. Cross-references to cases are computed dynamically by `ArticleCases.tsx` which filters `allFiles` by `ruling-articles` matching the article number.
+
+---
+
+## Table C: General/Index Page Frontmatter Fields
+
+Fields found on `content/index.md`, browse pages, and generated index files.
+
+| Field | Type | Required | Origin | Processing | Used By |
+|-------|------|----------|--------|-----------|---------|
+| `title` | string | Yes | Manual | E.g. `Welcome!`, `Browse by topic` | All title-consuming components |
+| `subtitle` | string | No | Manual | Descriptive subtitle | Display only |
+| `tags` | string[] | No | Manual | E.g. `["hidden"]` to exclude from listings | `TagList.tsx`, `TagContent.tsx`, `RecentNotes.tsx` (filter), search index |
+| `cssclasses` | string[] | No | Manual | E.g. `["no-date", "no-title"]` | `Content.tsx` (applied as CSS classes on `<article>`) |
+
+---
+
+## Table D: Quartz-Internal VFile Data (QuartzPluginData)
+
+These fields are attached to `vfile.data` during the Quartz transform pipeline. They do not exist in markdown files; they are computed at build time.
+
+**Source:** `quartz/plugins/vfile.ts` + module augmentations in each transformer.
+
+| Field | Type | Set By | Source File | Description | Consumed By |
+|-------|------|--------|-------------|-------------|-------------|
+| `slug` | `FullSlug` | Core VFile setup | `quartz/build.ts` | Canonical page slug (e.g. `Case-law/C-492-23`) | All components via `fileData.slug`, link resolution, graph, search |
+| `filePath` | `FilePath` | Core VFile setup | `quartz/build.ts` | Disk path (e.g. `content/Case law/C-492-23.md`) | `Head.tsx`, `Content.tsx`, dep graph |
+| `relativePath` | `FilePath` | Core VFile setup | `quartz/build.ts` | Path relative to content dir | Internal path utilities |
+| `frontmatter` | object | `FrontMatter` transformer | `quartz/plugins/transformers/frontmatter.ts` | Parsed YAML/TOML frontmatter (see Tables A-C). Always has `title: string`. | Nearly all components |
+| `aliases` | `FullSlug[]` | `FrontMatter` transformer | `quartz/plugins/transformers/frontmatter.ts` | Resolved alias slugs from `frontmatter.aliases`. Pushed into `allSlugs`. | `aliases.ts` emitter (redirect pages) |
+| `dates` | `{ created: Date, modified: Date, published: Date }` | `CreatedModifiedDate` transformer | `quartz/plugins/transformers/lastmod.ts` | Resolved dates from frontmatter, git history, or filesystem. Priority order configurable. | `ContentMeta.tsx`, `PageList.tsx`, `RecentNotes.tsx`, `FolderContent.tsx`, sitemap, RSS |
+| `links` | `SimpleSlug[]` | `CrawlLinks` transformer | `quartz/plugins/transformers/links.ts` | All outgoing internal links from this page. | `Backlinks.tsx` (reverse lookup), graph edges, `ContentIndex` (`links` field) |
+| `description` | string | `Description` transformer | `quartz/plugins/transformers/description.ts` | Auto-generated meta description (first N chars of content). | `Head.tsx` (OG meta), RSS feed description |
+| `text` | string | `Description` transformer | `quartz/plugins/transformers/description.ts` | Plain-text extraction of full page content (HTML stripped). | `ContentMeta.tsx` (reading time calc), `ContentIndex` (`content` field for search) |
+| `toc` | `TocEntry[]` | `TableOfContents` transformer | `quartz/plugins/transformers/toc.ts` | Array of `{ depth: number, text: string, slug: string }` heading entries. | `TableOfContents.tsx` (renders TOC sidebar) |
+| `collapseToc` | boolean | `TableOfContents` transformer | `quartz/plugins/transformers/toc.ts` | Whether TOC starts collapsed. | `TableOfContents.tsx` (initial collapse state) |
+| `htmlAst` | `HtmlRoot` | `ObsidianFlavoredMarkdown` transformer | `quartz/plugins/transformers/ofm.ts` | Full HTML AST clone for transclusion support. | `renderPage.tsx` (resolves `![[embed]]` transclusions) |
+| `blocks` | `Record<string, Element>` | `ObsidianFlavoredMarkdown` transformer | `quartz/plugins/transformers/ofm.ts` | Map of block IDs to HTML elements (for `^blockref` transclusions). | `renderPage.tsx` (block-level transclusions) |
+| `hasMermaidDiagram` | boolean | `ObsidianFlavoredMarkdown` transformer | `quartz/plugins/transformers/ofm.ts` | Whether page contains mermaid diagrams. | `renderPage.tsx` (conditionally loads mermaid.js) |
+
+### TocEntry Structure
+
+```
+{
+  depth: number    // Heading level (1-6)
+  text: string     // Heading text content
+  slug: string     // Anchor slug for linking (e.g. "introduction")
+}
+```
+
+---
+
+## Table E: Global Configuration Fields
+
+**Source:** `quartz/cfg.ts` -> `GlobalConfiguration` interface. Set in `quartz.config.ts`.
+
+| Field | Type | Default (GDPRed) | Description | Used By |
+|-------|------|-------------------|-------------|---------|
+| `pageTitle` | string | `"GDPRed"` | Site title displayed in header | `PageTitle.tsx`, RSS feed `<title>`, OG meta |
+| `pageTitleSuffix` | string? | _(none)_ | Appended to page titles in `<title>` tag | `Head.tsx` |
+| `enableSPA` | boolean | `true` | Single-page-app navigation (prevents full reloads) | Client-side router (`spa.inline.ts`) |
+| `enablePopovers` | boolean | `true` | Wikipedia-style link previews on hover | `popover.inline.ts` |
+| `analytics` | Analytics | _(null or configured)_ | Analytics provider config | `Head.tsx` (injects tracking script) |
+| `ignorePatterns` | string[] | `["private", ...]` | Glob patterns for files to exclude from build | `quartz/build.ts` (file discovery) |
+| `defaultDateType` | `"created" \| "modified" \| "published"` | `"created"` | Which date to display by default | `getDate()` utility, `ContentMeta.tsx` |
+| `baseUrl` | string? | `"gdpred.milos.no"` | Base URL for sitemap, RSS, CNAME | Sitemap URLs, RSS links, OG meta URLs, CNAME file |
+| `generateSocialImages` | boolean \| SocialImageOptions | _(configured)_ | Auto-generate OG images | `Head.tsx` (Satori-based image generation) |
+| `theme` | Theme | _(see below)_ | Typography, colors, font config | `Head.tsx` (font loading), all CSS variables |
+| `locale` | ValidLocale | `"en-US"` | BCP 47 locale for dates and UI strings | All components using `i18n()`, date formatting |
+
+### Theme Sub-Structure
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `theme.typography.header` | string | Header font family (e.g. `IBM Plex Sans`) |
+| `theme.typography.body` | string | Body font family |
+| `theme.typography.code` | string | Code font family |
+| `theme.cdnCaching` | boolean | Whether to use CDN for fonts |
+| `theme.fontOrigin` | `"googleFonts" \| "local"` | Font loading source |
+| `theme.colors.lightMode` | ColorScheme | 9 color tokens for light theme |
+| `theme.colors.darkMode` | ColorScheme | 9 color tokens for dark theme |
+
+### ColorScheme Tokens
+
+Each mode (light/dark) defines: `light`, `lightgray`, `gray`, `darkgray`, `dark`, `secondary`, `tertiary`, `highlight`, `textHighlight`.
+
+---
+
+## Table F: Content Index (Search/Graph Payload)
+
+**Source:** `quartz/plugins/emitters/contentIndex.ts`
+**Output:** `static/contentIndex.json`
+
+This is the JSON blob loaded client-side for search and graph visualization.
+
+| Field | Type | Source | Used By Search | Used By Graph | In JSON |
+|-------|------|--------|---------------|---------------|---------|
+| _key_ (slug) | `FullSlug` | `vfile.data.slug` | Result linking | Node ID | Yes |
+| `title` | string | `frontmatter.title` | Indexed (tokenize: forward) | Node label | Yes |
+| `links` | `SimpleSlug[]` | `vfile.data.links` | Not indexed | Edge targets | Yes |
+| `tags` | string[] | `frontmatter.tags` | Indexed + tag filter | Tag nodes (if enabled) | Yes |
+| `content` | string | `vfile.data.text` | Indexed (tokenize: forward) | Not used | Yes |
+| `richContent` | string? | HAST-to-HTML of full page | Not used | Not used | Only if `rssFullHtml` |
+| `date` | Date? | `getDate()` from dates | Not used | Not used | **No** (stripped) |
+| `description` | string? | `vfile.data.description` | Not used | Not used | **No** (stripped) |
+
+**Note:** `date` and `description` are stripped from `contentIndex.json` to reduce file size. They are only used for sitemap.xml and RSS (index.xml).
+
+### FlexSearch Index Configuration (client-side)
+
+```
+Document index fields:
+  - title     (tokenize: "forward")
+  - content   (tokenize: "forward")
+  - tags      (tokenize: "forward")
+Tag field: "tags" (used for #tag filtering)
+Max results: 8 (basic search), 5 (tag search)
+```
+
+### Graph Data Usage (client-side)
+
+```
+Nodes: Each slug in contentIndex -> node
+  - Label: ContentDetails.title
+  - Color: secondary (current), tertiary (visited), gray (unvisited)
+Edges: ContentDetails.links -> directed edges to other nodes
+Tag nodes (optional): ContentDetails.tags -> synthetic nodes prefixed with #
+Neighborhood: BFS from current page to configurable depth
+Rendering: D3.js force simulation + Pixi.js GPU rendering
+```
+
+---
+
+## Table G: Pipeline Script I/O
+
+Complete input/output mapping for every processing script.
+
+| Script | Input | Processing | Output |
+|--------|-------|-----------|--------|
+| `sparql-discover.js` | SPARQL endpoint + existing `content/Case law/` filenames | Queries Publications Office, filters/deduplicates, compares against existing | `scripts/pipeline/new-cases.json` |
+| `fetch-html.js` | `new-cases.json` (caseCelex IDs) | HTTP GET from EUR-Lex with rate limiting | `scripts/pipeline/downloaded/{celex}.html` |
+| `generate-frontmatter.js` | Case data object + raw HTML | Cheerio parsing of ruling, topics, articles; merge SPARQL + HTML data | YAML frontmatter object (returned to caller) |
+| `html-to-md.cjs` | Raw EUR-Lex HTML | Turndown HTML-to-Markdown, paragraph consolidation, numbering cleanup | Markdown body string (returned to caller) |
+| `assemble-case.js` | Case data + HTML file path | Calls generate-frontmatter + html-to-md, combines | `content/Case law/{case-number}.md` |
+| `run-pipeline.js` | CLI args (`--dry-run`, `--force-celex`, `--limit`) | Orchestrates discover -> download -> assemble -> post-process | All outputs above + console summary |
+| `extract_case_articles.cjs` | All `content/Case law/*.md` | Parses frontmatter, extracts `[[Article N]]` refs, builds cross-ref maps | `cases_by_article.md`, `articles_by_case.md` (root) |
+| `extract_article_rulings.js` | `key-articles-by-case.md` + case law files | Extracts ruling paragraphs per article per case | `content/article-rulings.md` |
+| `process_article_refs.cjs` | All `content/**/*.md` | Finds `[[Article N]]` where N>99 (invalid), replaces with plain text | Modified .md files + `article_modifications.md` log + `backup_content/` |
+| `apply_json_frontmatter.js` | `case-metadata.json` + case law .md files | Maps JSON metadata to YAML, replaces frontmatter | Modified .md files (with `.bak_json_apply` backups) |
+| `check_frontmatter.js` | All `content/**/*.md` | Validates YAML syntax, checks for missing frontmatter | Console report (no file changes) |
+| `generate-timeline.js` | All `content/Case law/*.md` | Extracts date/title/parties/topics, groups by month, generates HTML | Inserts timeline HTML into `content/index.md` |
+| `generate-case-grid.js` | All `content/Case law/*.md` | Extracts date/title/parties/topics, generates card grid HTML | `content/case-law-grid.md` |
+
+---
+
+## Table H: Component Data Consumption
+
+What data each UI component reads and how it uses it.
+
+| Component | fileData Fields | allFiles Fields | cfg Fields | Renders |
+|-----------|----------------|-----------------|-----------|---------|
+| `ArticleTitle.tsx` | `frontmatter.title` | -- | -- | `<h1>` with page title |
+| `Parties.tsx` | `frontmatter.parties` | -- | -- | Styled `<h2>` with italic parties text |
+| `NowReading.tsx` | `frontmatter["ruling-articles"]`, `slug` | -- | -- | Article chips with links to `/Articles/Article-N` |
+| `ArticleCases.tsx` | `slug` (extracts article number) | `frontmatter["ruling-articles"]`, `slug`, `frontmatter.title`, `frontmatter.date`, `frontmatter.parties` | `locale` | Collapsible list of cases referencing this article |
+| `ContentMeta.tsx` | `text`, `dates`, `slug` | -- | `locale` | Date display + reading time (e.g. "5 min read") |
+| `TagList.tsx` | `frontmatter.tags`, `slug` | -- | -- | Tag links to `/tags/{slug}` |
+| `Head.tsx` | `filePath`, `frontmatter.title`, `description`, `frontmatter.socialImage`, `slug` | -- | `generateSocialImages`, `locale`, `pageTitleSuffix`, `baseUrl`, `theme`, `pageTitle` | `<head>` with meta tags, OG/Twitter cards, fonts, CSS/JS |
+| `PageTitle.tsx` | `slug` | -- | `pageTitle`, `locale` | Site title link to homepage |
+| `Backlinks.tsx` | `slug` | `links` (reverse lookup), `slug`, `frontmatter.title`, `frontmatter.parties`, `frontmatter.subtitle` | `locale` | List of pages linking to current page |
+| `TableOfContents.tsx` | `toc`, `collapseToc` | -- | `locale` | Collapsible TOC with depth-based indentation |
+| `Breadcrumbs.tsx` | `slug`, `frontmatter.title` | `slug`, `frontmatter.title` (index files) | -- | Navigation breadcrumb trail |
+| `Explorer.tsx` | _(nested)_ | `slug` (builds file tree) | `locale` | Sidebar file explorer navigation |
+| `Graph.tsx` | -- | -- | `locale` | D3/Pixi graph (data loaded client-side from contentIndex.json) |
+| `Search.tsx` | -- | -- | `locale` | Search UI (data loaded client-side from contentIndex.json) |
+| `Content.tsx` | `filePath`, `frontmatter.cssclasses` | -- | -- | `<article>` with rendered markdown content |
+| `FolderContent.tsx` | `slug`, `frontmatter.cssclasses`, `description` | `slug`, `dates`, `frontmatter.title`, `frontmatter.tags` | `locale` | Folder page with child page listings |
+| `TagContent.tsx` | `slug`, `frontmatter.cssclasses`, `description` | `frontmatter.tags` (filter) | `locale` | Tag index or single-tag page with page listings |
+| `TopicExplorer.tsx` | `slug` | `slug`, `frontmatter["case-number"]`, `frontmatter.title` | -- | Hierarchical GDPR topic browser with case links |
+| `renderPage.tsx` | `frontmatter.lang`, `slug`, `hasMermaidDiagram` | `slug`, `frontmatter.title`, `htmlAst`, `blocks` | `locale` | Full HTML page assembly with transclusion resolution |
+| `RecentNotes.tsx` | `slug` | `frontmatter.title`, `frontmatter.tags`, `dates` | `locale` | Recent pages list sorted by date |
+| `PageList.tsx` | `slug` | `frontmatter.title`, `frontmatter.tags`, `dates` | `locale` | Generic sorted/limited page listing |
+| `Body.tsx` | -- | -- | -- | Wrapper `<div id="quartz-body">` |
+
+---
+
+## Table I: Frontmatter Alias Resolution
+
+The `FrontMatter` transformer coalesces multiple possible field names into canonical fields.
+
+**Source:** `quartz/plugins/transformers/frontmatter.ts:84-110`
+
+| Canonical Field | Accepted Aliases (checked in order) | Coercion |
+|----------------|-------------------------------------|----------|
+| `tags` | `tags`, `tag` | Coerced to string[], split on `,` if string, deduplicated via `slugTag()` |
+| `aliases` | `aliases`, `alias` | Coerced to string[], resolved to `FullSlug[]` relative to file directory |
+| `cssclasses` | `cssclasses`, `cssclass` | Coerced to string[] |
+| `socialImage` | `socialImage`, `image`, `cover` | Kept as string |
+| `created` | `created`, `date` | Kept as string (later parsed to Date by `lastmod.ts`) |
+| `modified` | `modified`, `lastmod`, `updated`, `last-modified` | Kept as string (later parsed to Date by `lastmod.ts`) |
+| `published` | `published`, `publishDate`, `date` | Kept as string (later parsed to Date by `lastmod.ts`) |
+
+---
+
+## Table J: Output Artifacts
+
+All files generated by the Quartz build.
+
+| Artifact | Generator | Format | Contains |
+|----------|-----------|--------|----------|
+| `public/{slug}/index.html` | Page emitters (`ContentPage`, `FolderPage`, `TagPage`) | HTML | Full rendered page with all component output |
+| `public/static/contentIndex.json` | `ContentIndex` emitter | JSON | `Map<slug, {title, links, tags, content}>` |
+| `public/sitemap.xml` | `ContentIndex` emitter | XML | All slugs with `<lastmod>` dates |
+| `public/index.xml` | `ContentIndex` emitter | XML (RSS) | Recent pages with title, link, description, pubDate |
+| `public/{alias}/index.html` | `Aliases` emitter | HTML | Meta-refresh redirect + canonical link |
+| `public/static/*` | `Assets` emitter | Various | Static files (CSS, JS, fonts, images) |
+| `public/CNAME` | `CNAME` emitter | Text | `gdpred.milos.no` |
+| Tag index pages | `TagPage` emitter | HTML | Tag listing or per-tag page list |
+| Folder index pages | `FolderPage` emitter | HTML | Folder contents with child page listings |
+
+---
+
+## Data Flow Diagram
+
+```
+                    EXTERNAL SOURCES
+                    ================
+    ┌──────────────────┐     ┌──────────────────┐     ┌──────────────┐
+    │ SPARQL Endpoint   │     │  EUR-Lex HTML     │     │ case-metadata│
+    │ (Publications     │     │  (Court rulings)  │     │ .json        │
+    │  Office EU)       │     │                   │     │ (optional)   │
+    └────────┬─────────┘     └────────┬──────────┘     └──────┬───────┘
+             │                        │                        │
+    ┌────────▼─────────┐     ┌────────▼──────────┐    ┌───────▼────────┐
+    │sparql-discover.js│     │  fetch-html.js     │    │apply_json_     │
+    │  Discovers new   │     │  Downloads HTML    │    │frontmatter.js  │
+    │  cases           │     │  from EUR-Lex      │    │  Enriches FM   │
+    └────────┬─────────┘     └────────┬──────────┘    └───────┬────────┘
+             │                        │                        │
+             └──────────┬─────────────┘                        │
+                        │                                      │
+               ┌────────▼──────────┐                           │
+               │  assemble-case.js │                           │
+               │  ┌──────────────┐ │                           │
+               │  │generate-     │ │                           │
+               │  │frontmatter.js│ │                           │
+               │  └──────────────┘ │                           │
+               │  ┌──────────────┐ │                           │
+               │  │html-to-md.cjs│ │                           │
+               │  └──────────────┘ │                           │
+               └────────┬──────────┘                           │
+                        │                                      │
+                        ▼                                      ▼
+    ┌──────────────────────────────────────────────────────────────────┐
+    │                  content/Case law/*.md                           │
+    │  ┌─────────────────────────────────────────────────────────┐    │
+    │  │ YAML Frontmatter:                                       │    │
+    │  │   title, date, case-number, parties, topics,            │    │
+    │  │   final-ruling, ruling-articles, per-article,           │    │
+    │  │   [celex-id, gdpr-summary, operative_parts_structured]  │    │
+    │  ├─────────────────────────────────────────────────────────┤    │
+    │  │ Markdown Body:                                          │    │
+    │  │   Full court ruling text converted from HTML            │    │
+    │  └─────────────────────────────────────────────────────────┘    │
+    └────────────────────────────┬─────────────────────────────────────┘
+                                 │
+          POST-PROCESSING        │
+          ===============        │
+    ┌────────────────────────────┼────────────────────────────────┐
+    │                            ▼                                │
+    │  ┌──────────────────┐  ┌──────────────────┐  ┌──────────┐  │
+    │  │extract_case_     │  │extract_article_  │  │process_  │  │
+    │  │articles.cjs      │  │rulings.js        │  │article_  │  │
+    │  │→cases_by_article │  │→article-rulings  │  │refs.cjs  │  │
+    │  │→articles_by_case │  │  .md             │  │→fix >99  │  │
+    │  └──────────────────┘  └──────────────────┘  └──────────┘  │
+    │                                                             │
+    │  ┌──────────────────┐  ┌──────────────────┐                │
+    │  │generate-         │  │generate-case-    │                │
+    │  │timeline.js       │  │grid.js           │                │
+    │  │→index.md timeline│  │→case-law-grid.md │                │
+    │  └──────────────────┘  └──────────────────┘                │
+    └─────────────────────────────┬───────────────────────────────┘
+                                  │
+                                  ▼
+    ┌──────────────────────────────────────────────────────────────┐
+    │                    QUARTZ BUILD PIPELINE                     │
+    │                                                              │
+    │  PARSE ──► TRANSFORM ──► FILTER ──► EMIT                    │
+    │                                                              │
+    │  Parse:                                                      │
+    │    Markdown → AST (mdast) + VFile                            │
+    │                                                              │
+    │  Transform (Markdown stage):                                 │
+    │    FrontMatter    → vfile.data.frontmatter, .aliases         │
+    │    GFM            → Tables, strikethrough, autolinks         │
+    │    OFM            → Wikilinks, embeds, tags, .blocks,        │
+    │                     .htmlAst, .hasMermaidDiagram              │
+    │    Citations      → Bibliography references                  │
+    │    Linebreaks     → Hard line breaks                         │
+    │                                                              │
+    │  [Markdown AST → HTML AST conversion]                        │
+    │                                                              │
+    │  Transform (HTML stage):                                     │
+    │    CrawlLinks     → vfile.data.links (SimpleSlug[])          │
+    │    Description    → vfile.data.description, .text            │
+    │    TableOfContents→ vfile.data.toc, .collapseToc             │
+    │    CreatedModified→ vfile.data.dates                         │
+    │    SyntaxHighlight→ Code block theming                       │
+    │    Latex          → Math rendering                           │
+    │                                                              │
+    │  Filter:                                                     │
+    │    RemoveDrafts   → Excludes draft:true / publish:false      │
+    │                                                              │
+    │  Emit:                                                       │
+    │    ContentPage    → public/{slug}/index.html                 │
+    │    FolderPage     → public/{folder}/index.html               │
+    │    TagPage        → public/tags/{tag}/index.html             │
+    │    ContentIndex   → static/contentIndex.json + sitemap + RSS │
+    │    Aliases        → public/{alias}/index.html (redirects)    │
+    │    Assets         → public/static/* (CSS, JS, fonts)         │
+    │    CNAME          → public/CNAME                             │
+    └──────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Cross-Reference Systems
+
+### 1. Case → Article Links
+
+**Direction:** Case law pages reference GDPR articles.
+
+| Layer | Mechanism | Data Field |
+|-------|-----------|-----------|
+| Frontmatter | `ruling-articles: ["Article 17", "Article 21"]` | Explicit list |
+| Body text | `[[Article 17]]` wikilinks | Parsed by OFM transformer into `links` |
+| Component | `NowReading.tsx` reads `ruling-articles`, generates chip links | Direct frontmatter read |
+
+### 2. Article → Case Links (reverse)
+
+**Direction:** Article pages show which cases reference them.
+
+| Layer | Mechanism | Data Field |
+|-------|-----------|-----------|
+| Component | `ArticleCases.tsx` extracts article number from slug, filters `allFiles` where `ruling-articles` includes this article | Computed at render time from `allFiles` |
+| Backlinks | `Backlinks.tsx` finds all files whose `links` array contains current article's slug | Computed from `vfile.data.links` |
+
+### 3. Inter-Case Links
+
+**Direction:** Cases may link to other cases via wikilinks in body text.
+
+| Layer | Mechanism | Data Field |
+|-------|-----------|-----------|
+| Body text | `[[C-492-23]]` wikilinks | Parsed into `links` by OFM + CrawlLinks |
+| Graph | Edges drawn from `ContentDetails.links` in contentIndex.json | Client-side D3 rendering |
+| Backlinks | Reverse lookup of `links` array | `Backlinks.tsx` |
+
+### 4. Generated Cross-Reference Indexes
+
+| File | Generator | Structure |
+|------|-----------|-----------|
+| `cases_by_article.md` | `extract_case_articles.cjs` | Per case: list of referenced articles |
+| `articles_by_case.md` | `extract_case_articles.cjs` | Per article: list of referencing cases |
+| `article-rulings.md` | `extract_article_rulings.js` | Per article: relevant ruling text from each case |
+| `key-articles-by-case.md` | _(manual/generated)_ | Key articles grouped by case |
+
+### 5. Search System
+
+| Indexed Field | Source | Search Type |
+|--------------|--------|-------------|
+| `title` | `frontmatter.title` | Forward tokenization, prefix matching |
+| `content` | `vfile.data.text` (plain text) | Forward tokenization, prefix matching |
+| `tags` | `frontmatter.tags` | Tag filtering with `#` prefix, forward tokenization |
+
+### 6. Graph Visualization
+
+| Node Type | Source | Visual |
+|-----------|--------|--------|
+| Page node | Each slug in contentIndex | Circle, color varies by state |
+| Tag node (optional) | `ContentDetails.tags` | Circle with border, "light" color |
+| Edge (link) | `ContentDetails.links[i]` → target slug | Directed line |
+| Edge (tag) | Page slug → `tags/{tagname}` | Directed line |
+
+---
+
+## Appendix: Complete Transformer Pipeline Order
+
+As configured in `quartz.config.ts`:
+
+```
+1. FrontMatter        → Parse YAML, resolve aliases, coerce types
+2. CreatedModifiedDate → Resolve dates from frontmatter/git/filesystem
+3. Latex               → Render math expressions
+4. SyntaxHighlighting  → Highlight code blocks
+5. ObsidianFlavoredMarkdown → Wikilinks, embeds, tags, callouts, blocks
+6. GitHubFlavoredMarkdown   → Tables, strikethrough, autolinks
+7. CrawlLinks         → Resolve links, classify internal/external, populate links[]
+8. Description         → Extract plain text and meta description
+9. TableOfContents     → Generate heading tree
+```
+
+Each transformer can operate at three stages:
+- `textTransform`: Raw text manipulation before parsing
+- `markdownPlugins`: Remark plugins operating on mdast
+- `htmlPlugins`: Rehype plugins operating on hast
+
+---
+
+## Appendix: Slug Type System
+
+Quartz uses branded string types for type safety:
+
+| Type | Pattern | Example | Usage |
+|------|---------|---------|-------|
+| `FilePath` | Absolute, with extension | `content/Case law/C-492-23.md` | Disk I/O, dep graph |
+| `FullSlug` | No leading/trailing slash, may have `index` | `Case-law/C-492-23` | Canonical page identity |
+| `SimpleSlug` | No `/index`, no extension | `Case-law/C-492-23` | Links, graph edges, backlinks |
+| `RelativeURL` | Can be relative | `../Articles/Article-17` | href attributes in HTML |

--- a/SITE-FEATURES.md
+++ b/SITE-FEATURES.md
@@ -1,0 +1,68 @@
+# GDPRed Site Features
+
+## Global (every page)
+
+- Left sidebar: site title, full-text search, dark/light mode toggle, file explorer (collapsible folder tree of all content)
+- Breadcrumbs at the top (Home > Case law > C-492/23)
+- Link hover previews (Wikipedia-style popovers)
+- SPA navigation (no full page reloads)
+- Footer with author credit, LinkedIn, email, privacy policy
+
+## Article pages
+
+- Title and subtitle (e.g. "Article 17 — Right to erasure")
+- Full regulatory text of the GDPR article
+- "Cases referencing this article" — collapsible list of all cases that interpret this article, each showing case number, date, and parties
+- Backlinks — other pages that link to this article
+- Interactive graph showing this article's connections to cases and other articles
+- Table of contents (right sidebar, desktop only)
+
+No prev/next article navigation.
+
+## Case pages
+
+- Case number as title (e.g. "C-492/23")
+- Parties line (e.g. "Digi Kft. v Nemzeti Adatvédelmi Hatóság")
+- Date and reading time
+- Article chips — clickable badges for each GDPR article the case interprets, linking to the article page
+- Full ruling text (judgment header, procedural history, legal analysis, ruling)
+- Backlinks — other pages linking to this case
+- Interactive graph showing connections
+- Table of contents
+
+## Homepage
+
+- Welcome text and site description
+- Expandable FAQ (5 items)
+- Case law timeline — all cases grouped by month, most recent first
+
+## Browse pages
+
+- **Browse by topic** — 14 curated categories (e.g. "Data subject rights", "Remedies, liability, compensation"), each with subtopics linking to relevant cases
+- **Case grid** — card layout of all cases showing case number, date, parties, topics
+- **Topic explorer** — collapsible hierarchy (partial: 3 categories with ~25 cases mapped)
+
+## Search
+
+- Full-text search across all page titles, body text, and tags
+- Live results with preview snippets
+- Client-side (FlexSearch over a prebuilt JSON index)
+
+## Graph
+
+- Local graph: current page + immediate connections
+- Global graph toggle: entire site as a network
+- Interactive: drag, pan, zoom
+- Nodes = pages, edges = links between pages
+
+## File explorer
+
+- Hierarchical folder tree in left sidebar
+- Case law folder sorted newest-first by date
+- Folders expand/collapse, state remembered per session
+
+## Auto-generated outputs
+
+- RSS feed
+- Sitemap
+- Alias redirects (alternative URLs for joined cases)


### PR DESCRIPTION
## Summary

This PR adds a complete data schema map (`DATA-SCHEMA-MAP.md`) documenting every entity, field, relationship, and query in GDPRed. This document serves as a reference for anyone designing a database backend to replace the current flat-file Quartz system.

## Key Changes

- **Domain Overview**: Documented the three core entities (Cases, GDPR Articles, Topics) and their relationships
- **Entity Specifications**: Detailed field definitions, types, nullability, and examples for:
  - Cases (case-number, date, parties, topics, ruling-articles, per-article interpretations, etc.)
  - GDPR Articles (article_number, title, subtitle, body)
  - Topics (free-text labels from court tagging)
  - Topic Taxonomy (14-category curated browsing structure)
  - Operative Parts (structured ruling paragraphs)
  - Per-Article Interpretations (what each case says about specific articles)
  - General Pages (non-case/non-article content)

- **Relationship Map**: Visual and tabular representation of all many-to-many and one-to-many relationships

- **Query Catalog**: Documented all 12 queries the UI actually runs, with current implementation details and SQL equivalents:
  - Article → Cases lookup
  - Case → Articles lookup
  - Backlinks resolution
  - Topic category browsing
  - Full-text search
  - Link graph construction
  - Timeline and grid generation

- **Data Ingestion Pipeline**: Step-by-step walkthrough of how data enters the system:
  - SPARQL discovery of new cases
  - HTML download from EUR-Lex
  - Frontmatter extraction and transformation
  - HTML-to-Markdown conversion
  - Optional JSON enrichment
  - Post-processing scripts

- **Search & Graph**: Documented contentIndex.json structure and client-side search/graph configuration

- **Suggested Database Schema**: Complete normalized SQL schema with:
  - Core tables (cases, articles, pages)
  - Junction tables (case_ruling_articles, case_topics, etc.)
  - Taxonomy tables (taxonomy_categories, taxonomy_subtopics, taxonomy_case_refs)
  - Link and tag management
  - Full-text search support (PostgreSQL-specific)
  - Design rationale for key decisions

- **Appendices**: 
  - Quartz build-time computed fields and how to handle them in a database
  - Data flow diagram showing external sources → database → API → UI

## Notable Implementation Details

- Documented the variability in the `topics` field (3-9 per case, free-text, no controlled vocabulary)
- Clarified the distinction between raw court topics (`topics` array) and the curated taxonomy (14 categories)
- Noted that `per-article` uses pipe-delimited strings that need normalization
- Identified that TopicExplorer.tsx currently has hardcoded case mappings (25 cases across 11 subtopics) that should be data-driven
- Documented date format inconsistencies in existing data (plain date, ISO with time, quoted strings)
- Explained why `article_reference` in per-article interpretations must be a string (includes sub-paragraphs like "Article 2(c)")

This document provides the foundation for designing a proper database backend and API layer to replace the static site generation approach.

https://claude.ai/code/session_0151768LWnwi2eqvsFcy3xmU